### PR TITLE
feat: 토큰을 통한 회원 정보 조회 구현

### DIFF
--- a/module-independent/src/main/java/com/depromeet/type/member/MemberSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/member/MemberSuccessType.java
@@ -9,7 +9,8 @@ public enum MemberSuccessType implements SuccessType {
     UPDATE_NAME_SUCCESS("MEMBER_4", "멤버 이름 수정에 성공하였습니다"),
     UPDATE_GENDER_SUCCESS("MEMBER_5", "멤버 성별 수정에 성공하였습니다"),
     SEARCH_MEMBER_SUCCESS("MEMBER_6", "멤버 검색에 성공하였습니다"),
-    UPDATE_SUCCESS("MEMBER_7", "멤버 정보 수정에 성공하였습니다");
+    UPDATE_SUCCESS("MEMBER_7", "멤버 정보 수정에 성공하였습니다"),
+    GET_DETAIL_SUCCESS("MEMBER_8", "멤버 정보 조회에 성공하였습니다");
 
     private final String code;
 

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberApi.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberApi.java
@@ -39,4 +39,7 @@ public interface MemberApi {
             @LoginMember Long memberId,
             @RequestParam(name = "nameQuery", required = false) String nameQuery,
             @RequestParam(name = "cursorId", required = false) Long cursorId);
+
+    @Operation(summary = "access token을 통한 로그인 member 정보 조회")
+    ApiResponse<MemberDetailResponse> getDetail(@LoginMember Long memberId);
 }

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
@@ -66,4 +66,9 @@ public class MemberController implements MemberApi {
         MemberSearchResponse response = memberFacade.searchByName(memberId, nameQuery, cursorId);
         return ApiResponse.success(MemberSuccessType.SEARCH_MEMBER_SUCCESS, response);
     }
+
+    @GetMapping
+    public ApiResponse<MemberDetailResponse> getDetail(@LoginMember Long memberId) {
+        return ApiResponse.success(MemberSuccessType.GET_DETAIL_SUCCESS, memberFacade.findDetailById(memberId));
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
@@ -69,6 +69,7 @@ public class MemberController implements MemberApi {
 
     @GetMapping
     public ApiResponse<MemberDetailResponse> getDetail(@LoginMember Long memberId) {
-        return ApiResponse.success(MemberSuccessType.GET_DETAIL_SUCCESS, memberFacade.findDetailById(memberId));
+        return ApiResponse.success(
+                MemberSuccessType.GET_DETAIL_SUCCESS, memberFacade.findDetailById(memberId));
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
@@ -7,14 +7,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemberDetailResponse(
         @Schema(description = "멤버 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-        Long id,
+                Long id,
         @Schema(description = "닉네임", example = "김스위미", requiredMode = Schema.RequiredMode.REQUIRED)
-        String nickname,
+                String nickname,
         @Schema(description = "목표", example = "1000", requiredMode = Schema.RequiredMode.REQUIRED)
-        Integer goal,
+                Integer goal,
         @Schema(description = "프로필 이미지 URL", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-        String profileImageUrl) {
+                String profileImageUrl) {
     public static MemberDetailResponse of(Member member) {
-        return new MemberDetailResponse(member.getId(), member.getNickname(), member.getGoal(), member.getProfileImageUrl());
+        return new MemberDetailResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getGoal(),
+                member.getProfileImageUrl());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
@@ -14,11 +14,18 @@ public record MemberDetailResponse(
                 Integer goal,
         @Schema(description = "프로필 이미지 URL", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
                 String profileImageUrl) {
-    public static MemberDetailResponse of(Member member) {
+    public static MemberDetailResponse of(Member member, String profileImageOrigin) {
         return new MemberDetailResponse(
                 member.getId(),
                 member.getNickname(),
                 member.getGoal(),
-                member.getProfileImageUrl());
+                getProfileImageUrl(profileImageOrigin, member.getProfileImageUrl()));
+    }
+
+    private static String getProfileImageUrl(String profileImageOrigin, String profileImageUrl) {
+        if (profileImageUrl == null) {
+            return null;
+        }
+        return profileImageOrigin + "/" + profileImageUrl;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
@@ -1,0 +1,20 @@
+package com.depromeet.member.dto.response;
+
+import com.depromeet.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record MemberDetailResponse(
+        @Schema(description = "멤버 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long id,
+        @Schema(description = "닉네임", example = "김스위미", requiredMode = Schema.RequiredMode.REQUIRED)
+        String nickname,
+        @Schema(description = "목표", example = "1000", requiredMode = Schema.RequiredMode.REQUIRED)
+        Integer goal,
+        @Schema(description = "프로필 이미지 URL", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        String profileImageUrl) {
+    public static MemberDetailResponse of(Member member) {
+        return new MemberDetailResponse(member.getId(), member.getNickname(), member.getGoal(), member.getProfileImageUrl());
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -8,6 +8,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.dto.request.MemberUpdateRequest;
+import com.depromeet.member.dto.response.MemberDetailResponse;
 import com.depromeet.member.dto.response.MemberProfileResponse;
 import com.depromeet.member.dto.response.MemberSearchResponse;
 import com.depromeet.member.dto.response.MemberUpdateResponse;
@@ -68,5 +69,10 @@ public class MemberFacade {
         MemberSearchPage memberSearchPage =
                 memberUseCase.searchMemberByName(memberId, nameQuery, cursorId);
         return MemberSearchResponse.toMemberSearchResponse(memberSearchPage, profileImageOrigin);
+    }
+
+    public MemberDetailResponse findDetailById(Long memberId) {
+        Member member = memberUseCase.findById(memberId);
+        return MemberDetailResponse.of(member);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -73,6 +73,6 @@ public class MemberFacade {
 
     public MemberDetailResponse findDetailById(Long memberId) {
         Member member = memberUseCase.findById(memberId);
-        return MemberDetailResponse.of(member);
+        return MemberDetailResponse.of(member, profileImageOrigin);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #224

## 📌 작업 내용 및 특이사항
- 토큰을 통해 회원 정보를 조회할 수 있는 API를 구현하였습니다.

## 📝 참고사항
- 응답 성공 시 (프로필 이미지 있는 경우)
<img width="833" alt="Screenshot 2024-08-19 at 15 41 43" src="https://github.com/user-attachments/assets/4b446b37-8b96-450c-b536-807e1a6012a0">

- 응답 성공 시 (프로필 이미지 없는 경우
<img width="848" alt="Screenshot 2024-08-19 at 15 33 42" src="https://github.com/user-attachments/assets/b2e28cb1-31eb-454e-b4a9-afd929fd81b5">
