### PR TITLE
feat: 로그인 성공 응답에 최초 로그인 여부 표시

### DIFF
--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
@@ -4,8 +4,6 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 
-import java.util.Optional;
-
 public interface MemberUseCase {
     Member findById(Long id);
 

--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
@@ -4,6 +4,8 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 
+import java.util.Optional;
+
 public interface MemberUseCase {
     Member findById(Long id);
 
@@ -12,4 +14,8 @@ public interface MemberUseCase {
     void deleteById(Long id);
 
     MemberSearchPage searchMemberByName(Long memberId, String nameQuery, Long cursorId);
+
+    Member findByProviderId(String providerId);
+
+    Member createMemberBy(SocialMemberCommand command);
 }

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -19,8 +19,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @Transactional
 @RequiredArgsConstructor

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -19,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -61,6 +63,23 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUp
     @Override
     public MemberSearchPage searchMemberByName(Long memberId, String nameQuery, Long cursorId) {
         return memberPersistencePort.searchByNameQuery(memberId, nameQuery, cursorId);
+    }
+
+    @Override
+    public Member findByProviderId(String providerId) {
+        return memberPersistencePort.findByProviderId(providerId).orElse(null);
+    }
+
+    @Override
+    public Member createMemberBy(SocialMemberCommand command) {
+        Member member =
+                Member.builder()
+                        .nickname(command.name())
+                        .email(command.email())
+                        .role(MemberRole.USER)
+                        .providerId(command.providerId())
+                        .build();
+        return memberPersistencePort.save(member);
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
@@ -4,7 +4,11 @@ import com.depromeet.auth.vo.JwtToken;
 import java.util.Objects;
 
 public record JwtTokenResponse(
-        Long userId, String nickname, Boolean isSignUpComplete, String accessToken, String refreshToken) {
+        Long userId,
+        String nickname,
+        Boolean isSignUpComplete,
+        String accessToken,
+        String refreshToken) {
     public JwtTokenResponse {
         Objects.requireNonNull(userId);
         Objects.requireNonNull(accessToken);
@@ -13,6 +17,10 @@ public record JwtTokenResponse(
 
     public static JwtTokenResponse of(JwtToken token, String nickname, Boolean isSignUpComplete) {
         return new JwtTokenResponse(
-                token.userId(), nickname, isSignUpComplete, token.accessToken(), token.refreshToken());
+                token.userId(),
+                nickname,
+                isSignUpComplete,
+                token.accessToken(),
+                token.refreshToken());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/response/JwtTokenResponse.java
@@ -4,15 +4,15 @@ import com.depromeet.auth.vo.JwtToken;
 import java.util.Objects;
 
 public record JwtTokenResponse(
-        Long userId, String nickname, String accessToken, String refreshToken) {
+        Long userId, String nickname, Boolean isSignUpComplete, String accessToken, String refreshToken) {
     public JwtTokenResponse {
         Objects.requireNonNull(userId);
         Objects.requireNonNull(accessToken);
         Objects.requireNonNull(refreshToken);
     }
 
-    public static JwtTokenResponse of(JwtToken token, String nickname) {
+    public static JwtTokenResponse of(JwtToken token, String nickname, Boolean isSignUpComplete) {
         return new JwtTokenResponse(
-                token.userId(), nickname, token.accessToken(), token.refreshToken());
+                token.userId(), nickname, isSignUpComplete, token.accessToken(), token.refreshToken());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -20,8 +20,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Transactional


### PR DESCRIPTION
## 🌱 관련 이슈

- close #226

## 📌 작업 내용 및 특이사항
- 소셜로그인에 성공했을 때, 최초가입인지 재로그인인지 구분할 수 있도록 Boolean 필드를 추가합니다.
- 해당 필드를 통해, 회원가입 플로우를 진행할지 말지 결정합니다.
- `isSignUpComplete` 필드가 false라면 최초 로그인입니다.
- `isSignUpComplete` 필드가 true라면 재로그인입니다.

## 📝 참고사항
- 성공 응답 (최초 로그인 시)
<img width="388" alt="Screenshot 2024-08-19 at 16 09 48" src="https://github.com/user-attachments/assets/e2c0f179-ac47-4abd-a1fd-d4cf3a21b7b9">

- 성공 응답 (재로그인 시)
<img width="385" alt="Screenshot 2024-08-19 at 16 10 03" src="https://github.com/user-attachments/assets/cf41afeb-1faf-4643-b26d-d12d8f0e9919">