### PR TITLE
feat: 이전, 다음 기록 조회 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
@@ -8,4 +8,8 @@ public interface GetMemoryUseCase {
     Memory findByIdWithMember(Long memoryId);
 
     int findOrderInMonth(Long memberId, Long memoryId, int month);
+
+    Memory findPrevMemoryById(Long memoryId);
+
+    Memory findNextMemoryById(Long memoryId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -24,4 +24,8 @@ public interface MemoryPersistencePort {
     Timeline findNextMemoryByMemberId(Long memberId, LocalDate cursorRecordAt, LocalDate recordAt);
 
     List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month);
+
+    Optional<Memory> findPrevMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
+
+    Optional<Memory> findNextMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -82,6 +82,24 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
     }
 
     @Override
+    public Memory findPrevMemoryById(Long memoryId) {
+        Memory memory = findById(memoryId);
+        return memoryPersistencePort
+                .findPrevMemoryByRecordAtAndMemberId(
+                        memory.getRecordAt(), memory.getMember().getId())
+                .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND_PREV));
+    }
+
+    @Override
+    public Memory findNextMemoryById(Long memoryId) {
+        Memory memory = findById(memoryId);
+        return memoryPersistencePort
+                .findNextMemoryByRecordAtAndMemberId(
+                        memory.getRecordAt(), memory.getMember().getId())
+                .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND_NEXT));
+    }
+
+    @Override
     @Transactional
     public Memory update(Long memoryId, UpdateMemoryCommand command, List<Stroke> strokes) {
         Memory memory = findById(memoryId);

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
@@ -5,6 +5,7 @@ import com.depromeet.memory.domain.vo.Timeline;
 import com.depromeet.memory.port.out.persistence.MemoryPersistencePort;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -193,5 +194,25 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     @Override
     public List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month) {
         return null;
+    }
+
+    @Override
+    public Optional<Memory> findPrevMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+        return data.stream()
+                .filter(
+                        item ->
+                                item.getRecordAt().isBefore(recordAt)
+                                        && item.getMember().getId().equals(memberId))
+                .max(Comparator.comparing(Memory::getRecordAt));
+    }
+
+    @Override
+    public Optional<Memory> findNextMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+        return data.stream()
+                .filter(
+                        item ->
+                                item.getRecordAt().isBefore(recordAt)
+                                        && item.getMember().getId().equals(memberId))
+                .min(Comparator.comparing(Memory::getRecordAt));
     }
 }

--- a/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
@@ -7,7 +7,9 @@ public enum MemoryErrorType implements ErrorType {
     NOT_FOUND("MEMORY_2", "기록이 존재하지 않습니다"),
     UPDATE_FAILED("MEMORY_3", "작성자가 아니라면 기록을 수정할 수 없습니다"),
     FORBIDDEN("MEMORY_4", "메모리에 접근 권한이 없습니다"),
-    ALREADY_CREATED("MEMORY_5", "해당 날짜에 이미 기록이 존재합니다");
+    ALREADY_CREATED("MEMORY_5", "해당 날짜에 이미 기록이 존재합니다"),
+    NOT_FOUND_PREV("MEMORY_6", "이전 기록이 존재하지 않습니다"),
+    NOT_FOUND_NEXT("MEMORY_7", "다음 기록이 존재하지 않습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/memory/MemorySuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/memory/MemorySuccessType.java
@@ -7,7 +7,9 @@ public enum MemorySuccessType implements SuccessType {
     GET_RESULT_SUCCESS("MEMORY_2", "수영 기록 조회에 성공하였습니다"),
     PATCH_RESULT_SUCCESS("MEMORY_3", "수영 기록 수정에 성공하였습니다"),
     GET_TIMELINE_SUCCESS("MEMORY_4", "타임라인 조회에 성공하였습니다"),
-    GET_CALENDAR_SUCCESS("MEMORY_5", "캘린더 조회에 성공하였습니다");
+    GET_CALENDAR_SUCCESS("MEMORY_5", "캘린더 조회에 성공하였습니다"),
+    GET_PREV_SUCCESS("MEMORY_6", "이전 수영 기록 조회에 성공하였습니다"),
+    GET_NEXT_SUCCESS("MEMORY_7", "다음 수영 기록 조회에 성공하였습니다");
 
     private final String code;
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -201,6 +201,52 @@ public class MemoryRepository implements MemoryPersistencePort {
         return toModel(memories);
     }
 
+    @Override
+    public Optional<Memory> findPrevMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+        MemoryEntity prevMemory =
+                queryFactory
+                        .selectFrom(memory)
+                        .join(memory.member, memberEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.pool, poolEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.memoryDetail, memoryDetailEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.strokes, strokeEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.images, imageEntity)
+                        .where(ltCursorRecordAt(recordAt), memberEq(memberId))
+                        .orderBy(memory.recordAt.desc())
+                        .fetchFirst();
+        if (prevMemory == null) {
+            return Optional.empty();
+        }
+        return Optional.of(prevMemory.toModel());
+    }
+
+    @Override
+    public Optional<Memory> findNextMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+        MemoryEntity prevMemory =
+                queryFactory
+                        .selectFrom(memory)
+                        .join(memory.member, memberEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.pool, poolEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.memoryDetail, memoryDetailEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.strokes, strokeEntity)
+                        .fetchJoin()
+                        .leftJoin(memory.images, imageEntity)
+                        .where(gtCursorRecordAt(recordAt), memberEq(memberId))
+                        .orderBy(memory.recordAt.asc())
+                        .fetchFirst();
+        if (prevMemory == null) {
+            return Optional.empty();
+        }
+        return Optional.of(prevMemory.toModel());
+    }
+
     private BooleanExpression loeRecordAt(LocalDate recordAt) {
         if (recordAt == null) {
             return null;

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
@@ -52,4 +52,10 @@ public interface MemoryApi {
             @LoginMember Long memberId,
             @RequestParam("year") Integer year,
             @RequestParam("month") Short month);
+
+    @Operation(summary = "수영 기록 record at 기준 이전 수영 기록 단일 조회")
+    ApiResponse<MemoryResponse> readPrev(@RequestParam("id") Long memoryId);
+
+    @Operation(summary = "수영 기록 record at 기준 다음 수영 기록 단일 조회")
+    ApiResponse<MemoryResponse> readNext(@RequestParam("id") Long memoryId);
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -77,4 +77,16 @@ public class MemoryController implements MemoryApi {
         CalendarResponse response = memoryFacade.getCalendar(memberId, year, month);
         return ApiResponse.success(MemorySuccessType.GET_CALENDAR_SUCCESS, response);
     }
+
+    @GetMapping("/prev")
+    public ApiResponse<MemoryResponse> readPrev(@RequestParam("id") Long memoryId) {
+        MemoryResponse response = memoryFacade.getPrevMemory(memoryId);
+        return ApiResponse.success(MemorySuccessType.GET_PREV_SUCCESS, response);
+    }
+
+    @GetMapping("/next")
+    public ApiResponse<MemoryResponse> readNext(@RequestParam("id") Long memoryId) {
+        MemoryResponse response = memoryFacade.getNextMemory(memoryId);
+        return ApiResponse.success(MemorySuccessType.GET_NEXT_SUCCESS, response);
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -105,4 +105,14 @@ public class MemoryFacade {
                 calendarUseCase.getCalendarByYearAndMonth(memberId, yearMonth);
         return CalendarResponse.of(member, calendarMemories);
     }
+
+    public MemoryResponse getPrevMemory(Long memoryId) {
+        Memory prevMemory = getMemoryUseCase.findPrevMemoryById(memoryId);
+        return MemoryResponse.from(prevMemory);
+    }
+
+    public MemoryResponse getNextMemory(Long memoryId) {
+        Memory nextMemory = getMemoryUseCase.findNextMemoryById(memoryId);
+        return MemoryResponse.from(nextMemory);
+    }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #228

## 📌 작업 내용 및 특이사항
- 기록 상세 페이지에서 사용될 이전, 다음 기록 조회를 구현하였습니다.

## 📝 참고사항
- 기록 데이터 구성
<img width="632" alt="Screenshot 2024-08-19 at 16 59 51" src="https://github.com/user-attachments/assets/69b83dae-c37b-444f-a7a6-1f07b9e4bb60">

- 이전 기록이 없는 경우
<img width="851" alt="Screenshot 2024-08-19 at 17 05 45" src="https://github.com/user-attachments/assets/55d77929-4f0a-407e-8a05-a2da1beae4f8">

- 이전 기록 조회 성공
<img width="853" alt="Screenshot 2024-08-19 at 17 01 34" src="https://github.com/user-attachments/assets/f27e46e1-581c-4c9e-afa7-be867bf50756">

- 다음 기록이 없는 경우
<img width="839" alt="Screenshot 2024-08-19 at 17 09 24" src="https://github.com/user-attachments/assets/ec61615c-fc55-42b5-ae5b-1deba1b2e185">

- 다음 기록 조회 성공
<img width="844" alt="Screenshot 2024-08-19 at 17 08 36" src="https://github.com/user-attachments/assets/3ae240a4-2f5e-448a-b0df-bb31ec9ea1cc">