### PR TITLE
fix: Jenkinsfile 깃허브 레포지토리 이름 변경

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# 15th-team2-BE
+# Swimie-server

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
     stages {
         stage('저장소 복제') {
             steps {
-                git branch: 'main', credentialsId: 'GITHUB_ACCESS_TOKEN', url: 'https://github.com/depromeet/15th-team2-BE'
+                git branch: 'main', credentialsId: 'GITHUB_ACCESS_TOKEN', url: 'https://github.com/depromeet/Swimie-server'
             }
         }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #232

## 📌 작업 내용 및 특이사항
- 깃허브 레포지토리 이름이 변경되어 Jenkins CICD가 동작하지 않는 문제가 있었습니다.