### PR TITLE
feat: 애플 회원 탈퇴 및 연결 끊기 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/auth/port/out/ApplePort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/ApplePort.java
@@ -4,4 +4,6 @@ import com.depromeet.dto.auth.AccountProfileResponse;
 
 public interface ApplePort {
     AccountProfileResponse getAppleAccountToken(String code, String origin);
+
+    void revokeAccount(String providerId);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
+++ b/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
@@ -46,6 +46,8 @@ public class SocialService implements SocialUseCase {
             kakaoPort.revokeAccount(providerId);
         } else if (accountType.startsWith("google")) {
             googlePort.revokeAccount(providerId);
+        } else if (accountType.startsWith("apple")) {
+            applePort.revokeAccount(providerId);
         }
     }
 }

--- a/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
@@ -21,4 +21,6 @@ public interface FollowUseCase {
     List<Following> getFollowingByMemberIdLimitThree(Long memberId);
 
     FriendCount countFriendByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
@@ -28,4 +28,6 @@ public interface FriendPersistencePort {
     List<Following> findFollowingByMemberIdLimitThree(Long memberId);
 
     FriendCount countFriendByMemberId(Long memberId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -69,4 +69,9 @@ public class FollowService implements FollowUseCase {
     public FriendCount countFriendByMemberId(Long memberId) {
         return friendPersistencePort.countFriendByMemberId(memberId);
     }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        friendPersistencePort.deleteByMemberId(memberId);
+    }
 }

--- a/module-domain/src/main/java/com/depromeet/image/port/in/ImageUpdateUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/image/port/in/ImageUpdateUseCase.java
@@ -8,4 +8,6 @@ public interface ImageUpdateUseCase {
     List<ImagePresignedUrlVo> updateImages(Memory memory, List<String> imageNames);
 
     void changeImageStatus(List<Long> imageIds);
+
+    void setNullByMemoryIds(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/image/port/out/persistence/ImagePersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/image/port/out/persistence/ImagePersistencePort.java
@@ -24,4 +24,6 @@ public interface ImagePersistencePort {
     void deleteAllByIds(List<Long> ids);
 
     void deleteAllByMemoryId(Long memoryId);
+
+    void setNullByMemoryIds(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/image/service/ImageUpdateService.java
+++ b/module-domain/src/main/java/com/depromeet/image/service/ImageUpdateService.java
@@ -59,6 +59,11 @@ public class ImageUpdateService implements ImageUpdateUseCase {
         imagePersistencePort.updateByImageIds(imageIds);
     }
 
+    @Override
+    public void setNullByMemoryIds(List<Long> memoryIds) {
+        imagePersistencePort.setNullByMemoryIds(memoryIds);
+    }
+
     private List<String> getExistingImageNames(List<Image> existingImages) {
         return existingImages.stream().map(Image::getImageName).toList();
     }

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -4,6 +4,8 @@ import com.depromeet.auth.port.out.persistence.RefreshRedisPersistencePort;
 import com.depromeet.exception.BadRequestException;
 import com.depromeet.exception.InternalServerException;
 import com.depromeet.exception.NotFoundException;
+import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
+import com.depromeet.image.port.out.persistence.ImagePersistencePort;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.MemberRole;
@@ -14,10 +16,17 @@ import com.depromeet.member.port.in.usecase.GoalUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
+import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.port.out.persistence.MemoryDetailPersistencePort;
+import com.depromeet.memory.port.out.persistence.MemoryPersistencePort;
+import com.depromeet.memory.port.out.persistence.StrokePersistencePort;
+import com.depromeet.reaction.port.out.persistence.ReactionPersistencePort;
 import com.depromeet.type.member.MemberErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -53,7 +62,6 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUp
 
     @Override
     public void deleteById(Long id) {
-        findById(id);
         memberPersistencePort.deleteById(id);
         refreshRedisPersistencePort.deleteData(id);
     }

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/DeleteMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/DeleteMemoryUseCase.java
@@ -1,0 +1,7 @@
+package com.depromeet.memory.port.in.usecase;
+
+import java.util.List;
+
+public interface DeleteMemoryUseCase {
+    void deleteAllMemoryDetailById(List<Long> memoryDetailIds);
+}

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
@@ -2,6 +2,8 @@ package com.depromeet.memory.port.in.usecase;
 
 import com.depromeet.memory.domain.Memory;
 
+import java.util.List;
+
 public interface GetMemoryUseCase {
     Memory findById(Long memoryId);
 
@@ -12,4 +14,6 @@ public interface GetMemoryUseCase {
     Memory findPrevMemoryById(Long memoryId);
 
     Memory findNextMemoryById(Long memoryId);
+
+    List<Memory> findByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/StrokeUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/StrokeUseCase.java
@@ -14,4 +14,6 @@ public interface StrokeUseCase {
     List<Stroke> getAllByMemoryId(Long memoryId);
 
     List<Stroke> updateAll(Memory memory, List<UpdateStrokeCommand> commands);
+
+    void deleteAllByMemoryId(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/UpdateMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/UpdateMemoryUseCase.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface UpdateMemoryUseCase {
     Memory update(Long memoryId, UpdateMemoryCommand command, List<Stroke> strokes);
+
+    void setNullByIds(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryDetailPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryDetailPersistencePort.java
@@ -1,10 +1,14 @@
 package com.depromeet.memory.port.out.persistence;
 
 import com.depromeet.memory.domain.MemoryDetail;
+
+import java.util.List;
 import java.util.Optional;
 
 public interface MemoryDetailPersistencePort {
     MemoryDetail save(MemoryDetail memoryDetail);
 
     Optional<MemoryDetail> update(Long id, MemoryDetail updateMemoryDetail);
+
+    void deleteAllById(List<Long> memoryDetailIds);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -29,4 +29,8 @@ public interface MemoryPersistencePort {
     Optional<Memory> findPrevMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
 
     Optional<Memory> findNextMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
+
+    List<Memory> findByMemberId(Long memberId);
+
+    void setNullByIds(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/StrokePersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/StrokePersistencePort.java
@@ -9,4 +9,6 @@ public interface StrokePersistencePort {
     List<Stroke> findAllByMemoryId(Long memoryId);
 
     void deleteById(Long id);
+
+    void deleteAllByMemoryId(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -10,6 +10,7 @@ import com.depromeet.memory.domain.Stroke;
 import com.depromeet.memory.port.in.command.CreateMemoryCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
 import com.depromeet.memory.port.in.usecase.CreateMemoryUseCase;
+import com.depromeet.memory.port.in.usecase.DeleteMemoryUseCase;
 import com.depromeet.memory.port.in.usecase.GetMemoryUseCase;
 import com.depromeet.memory.port.in.usecase.UpdateMemoryUseCase;
 import com.depromeet.memory.port.out.persistence.MemoryDetailPersistencePort;
@@ -27,7 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, GetMemoryUseCase {
+public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, GetMemoryUseCase, DeleteMemoryUseCase {
     private final PoolPersistencePort poolPersistencePort;
     private final MemoryPersistencePort memoryPersistencePort;
     private final MemoryDetailPersistencePort memoryDetailPersistencePort;
@@ -100,6 +101,11 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
     }
 
     @Override
+    public List<Memory> findByMemberId(Long memberId) {
+        return memoryPersistencePort.findByMemberId(memberId);
+    }
+
+    @Override
     @Transactional
     public Memory update(Long memoryId, UpdateMemoryCommand command, List<Stroke> strokes) {
         Memory memory = findById(memoryId);
@@ -123,6 +129,11 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
         return memoryPersistencePort
                 .update(memoryId, updateMemory)
                 .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND));
+    }
+
+    @Override
+    public void setNullByIds(List<Long> memoryIds) {
+        memoryPersistencePort.setNullByIds(memoryIds);
     }
 
     private void checkMemoryAlreadyExist(CreateMemoryCommand command, Long memberId) {
@@ -178,5 +189,10 @@ public class MemoryService implements CreateMemoryUseCase, UpdateMemoryUseCase, 
                             .orElseThrow(() -> new NotFoundException(PoolErrorType.NOT_FOUND));
         }
         return pool;
+    }
+
+    @Override
+    public void deleteAllMemoryDetailById(List<Long> memoryDetailIds) {
+        memoryDetailPersistencePort.deleteAllById(memoryDetailIds);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/memory/service/StrokeService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/StrokeService.java
@@ -114,4 +114,9 @@ public class StrokeService implements StrokeUseCase {
                 });
         return getAllByMemoryId(memory.getId());
     }
+
+    @Override
+    public void deleteAllByMemoryId(List<Long> memoryIds) {
+        strokePersistencePort.deleteAllByMemoryId(memoryIds);
+    }
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/DeleteReactionUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/DeleteReactionUseCase.java
@@ -2,4 +2,6 @@ package com.depromeet.reaction.port.in.usecase;
 
 public interface DeleteReactionUseCase {
     void deleteById(Long memberId, Long reactionId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
@@ -18,4 +18,6 @@ public interface ReactionPersistencePort {
     Optional<Reaction> getReactionById(Long reactionId);
 
     void deleteById(Long reactionId);
+
+    void deleteByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
@@ -65,6 +65,11 @@ public class ReactionService
     }
 
     @Override
+    public void deleteByMemberId(Long memberId) {
+        reactionPersistencePort.deleteByMemberId(memberId);
+    }
+
+    @Override
     public List<Reaction> getReactionsOfMemory(Long memoryId) {
         return reactionPersistencePort.getAllByMemoryId(memoryId);
     }

--- a/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
@@ -24,7 +24,8 @@ public enum AuthErrorType implements ErrorType {
     INVALID_APPLE_KEY_REQUEST("AUTH_20", "APPLE 공개키 요청에 실패하였습니다"),
     GENERATE_APPLE_PUBLIC_KEY_FAILED("AUTH_21", "APPLE 공개키 생성에 실패하였습니다"),
     CANNOT_FIND_MATCH_JWK("AUTH_22", "일치하는 APPLE JWK 를 찾을 수 없습니다"),
-    JWT_PARSE_FAILED("AUTH_23", "JWT PARSING 에 실패하였습니다");
+    JWT_PARSE_FAILED("AUTH_23", "JWT PARSING 에 실패하였습니다"),
+    REVOKE_APPLE_ACCOUNT_FAILED("AUTH_24", "APPLE 계정 연결 끊기에 실패하였습니다");
 
     private final String code;
     private final String message;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
@@ -215,4 +215,11 @@ public class FriendRepository implements FriendPersistencePort {
                         .fetchOne();
         return new FriendCount(result.get(0, Integer.class), result.get(1, Integer.class));
     }
+
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        queryFactory.delete(friend)
+                .where(friend.member.id.eq(memberId).or(friend.following.id.eq(memberId)))
+                .execute();
+    }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
@@ -6,16 +6,20 @@ import static com.depromeet.memory.entity.QMemoryEntity.memoryEntity;
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.ImageUploadStatus;
 import com.depromeet.image.entity.ImageEntity;
+import com.depromeet.image.entity.QImageEntity;
 import com.depromeet.image.port.out.persistence.ImagePersistencePort;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class ImageRepository implements ImagePersistencePort {
+    private final EntityManager em;
     private final JPAQueryFactory queryFactory;
     private final ImageJpaRepository imageJpaRepository;
 
@@ -91,5 +95,15 @@ public class ImageRepository implements ImagePersistencePort {
     @Override
     public void deleteAllByMemoryId(Long memoryId) {
         imageJpaRepository.deleteAllByMemoryId(memoryId);
+    }
+
+    @Override
+    public void setNullByMemoryIds(List<Long> memoryIds) {
+        queryFactory.update(imageEntity)
+                .setNull(imageEntity.memory.id)
+                .where(imageEntity.memory.id.in(memoryIds))
+                .execute();
+        em.flush();
+        em.clear();
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -178,6 +178,18 @@ public class MemoryEntity {
                 .build();
     }
 
+    public Memory toModelWithMemoryDetailOnly() {
+        return Memory.builder()
+                .id(this.id)
+                .memoryDetail(getMemoryDetailOrNull())
+                .recordAt(this.recordAt)
+                .startTime(this.startTime)
+                .endTime(this.endTime)
+                .lane(this.lane)
+                .diary(this.diary)
+                .build();
+    }
+
     private List<Image> getImageListOrNull() {
         return this.images != null
                 ? this.images.stream().map(ImageEntity::pureToModel).toList()

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryDetailRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryDetailRepository.java
@@ -3,6 +3,8 @@ package com.depromeet.memory.repository;
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.entity.MemoryDetailEntity;
 import com.depromeet.memory.port.out.persistence.MemoryDetailPersistencePort;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -25,5 +27,10 @@ public class MemoryDetailRepository implements MemoryDetailPersistencePort {
                         entity ->
                                 entity.update(MemoryDetailEntity.from(updateMemoryDetail))
                                         .toModel());
+    }
+
+    @Override
+    public void deleteAllById(List<Long> memoryDetailIds) {
+        memoryDetailJpaRepository.deleteAllById(memoryDetailIds);
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/StrokeRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/StrokeRepository.java
@@ -1,16 +1,22 @@
 package com.depromeet.memory.repository;
 
 import com.depromeet.memory.domain.Stroke;
+import com.depromeet.memory.entity.QStrokeEntity;
 import com.depromeet.memory.entity.StrokeEntity;
 import com.depromeet.memory.port.out.persistence.StrokePersistencePort;
 import java.util.List;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class StrokeRepository implements StrokePersistencePort {
+    private final JPAQueryFactory queryFactory;
     private final StrokeJpaRepository strokeJpaRepository;
+
+    QStrokeEntity stroke = QStrokeEntity.strokeEntity;
 
     @Override
     public Stroke save(Stroke stroke) {
@@ -27,5 +33,12 @@ public class StrokeRepository implements StrokePersistencePort {
     @Override
     public void deleteById(Long id) {
         strokeJpaRepository.deleteById(id);
+    }
+
+    @Override
+    public void deleteAllByMemoryId(List<Long> memoryIds) {
+        queryFactory.delete(stroke)
+                .where(stroke.memory.id.in(memoryIds))
+                .execute();
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionJpaRepository.java
@@ -3,4 +3,6 @@ package com.depromeet.reaction.repository;
 import com.depromeet.reaction.entity.ReactionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ReactionJpaRepository extends JpaRepository<ReactionEntity, Long> {}
+public interface ReactionJpaRepository extends JpaRepository<ReactionEntity, Long> {
+    void deleteByMemberId(Long memberId);
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
@@ -106,6 +106,11 @@ public class ReactionRepository implements ReactionPersistencePort {
         reactionJpaRepository.deleteById(reactionId);
     }
 
+    @Override
+    public void deleteByMemberId(Long memberId) {
+        reactionJpaRepository.deleteByMemberId(memberId);
+    }
+
     private BooleanExpression memberEq(Long memberId) {
         if (memberId == null) {
             return null;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #237

## 📌 작업 내용 및 특이사항
- 애플 계정의 회원 탈퇴와 연결 끊기를 구현합니다.
- 소셜 계정의 회원 탈퇴 시, 연관 관계가 있는 데이터를 삭제하거나 FK Null 처리를 진행합니다.
1. Memory 조회
2. Memory의 memoryDetailId Null
3. MemoryDetail 전체 삭제
4. Stroke 전체 삭제
5. Image 의 memoryId Null
6. Reaction 전체 삭제
7. Friend 전체 삭제 (팔로우, 팔로잉 모두 삭제)

## 📝 참고사항
- 회원 탈퇴 성공 시
<img width="843" alt="Screenshot 2024-08-20 at 16 05 11" src="https://github.com/user-attachments/assets/2e09de40-d511-46aa-ba2d-f26903b45397">

<details>
<summary>실행된 쿼리 접기/펼치기</summary>

```
Hibernate: 
    select
        me1_0.member_id,
        me1_0.email,
        me1_0.gender,
        me1_0.goal,
        me1_0.introduction,
        me1_0.last_viewed_following_log_at,
        me1_0.nickname,
        me1_0.profile_image_url,
        me1_0.provider_id,
        me1_0.role 
    from
        member_entity me1_0 
    where
        me1_0.member_id=?
Hibernate: 
    select
        me1_0.memory_id,
        me1_0.diary,
        me1_0.end_time,
        me1_0.lane,
        me1_0.member_id,
        md1_0.memory_detail_id,
        md1_0.heart_rate,
        md1_0.item,
        md1_0.kcal,
        md1_0.pace,
        me1_0.pool_id,
        me1_0.record_at,
        me1_0.start_time 
    from
        memory_entity me1_0 
    left join
        memory_detail_entity md1_0 
            on md1_0.memory_detail_id=me1_0.memory_detail_id 
    where
        me1_0.member_id=?
Hibernate: 
    update
        memory_entity me1_0 
    set
        memory_detail_id=null 
    where
        me1_0.memory_id in (?, ?)
MEMORY 조회 성공
Hibernate: 
    select
        mde1_0.memory_detail_id,
        mde1_0.heart_rate,
        mde1_0.item,
        mde1_0.kcal,
        mde1_0.pace 
    from
        memory_detail_entity mde1_0 
    where
        mde1_0.memory_detail_id=?
Hibernate: 
    select
        mde1_0.memory_detail_id,
        mde1_0.heart_rate,
        mde1_0.item,
        mde1_0.kcal,
        mde1_0.pace 
    from
        memory_detail_entity mde1_0 
    where
        mde1_0.memory_detail_id=?
MEMORY DETAIL 삭제 성공
Hibernate: 
    delete se1_0 
    from
        stroke_entity se1_0 
    where
        se1_0.memory_id in (?, ?)
STROKE 삭제 성공
Hibernate: 
    update
        image_entity ie1_0 
    set
        memory_id=null 
    where
        ie1_0.memory_id in (?, ?)
Hibernate: 
    delete 
    from
        memory_detail_entity 
    where
        memory_detail_id=?
Hibernate: 
    delete 
    from
        memory_detail_entity 
    where
        memory_detail_id=?
IMAGE PK NULL 성공
Hibernate: 
    select
        re1_0.reaction_id,
        re1_0.comment,
        re1_0.created_at,
        re1_0.emoji,
        re1_0.member_id,
        re1_0.memory_id 
    from
        reaction_entity re1_0 
    where
        re1_0.member_id=?
REACTION 삭제 성공
Hibernate: 
    delete fe1_0 
    from
        friend_entity fe1_0 
    where
        fe1_0.member_id=? 
        or fe1_0.following_id=?
FRIEND 삭제 성공
Hibernate: 
    select
        me1_0.member_id,
        me1_0.email,
        me1_0.gender,
        me1_0.goal,
        me1_0.introduction,
        me1_0.last_viewed_following_log_at,
        me1_0.nickname,
        me1_0.profile_image_url,
        me1_0.provider_id,
        me1_0.role 
    from
        member_entity me1_0 
    where
        me1_0.member_id=?
Hibernate: 
    delete 
    from
        member_entity 
    where
        member_id=?
```
</details>