### PR TITLE
hotfix: 타임라인 정렬 오류 수정 및 N+1 문제 개선 (#239)

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/service/TimelineService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/TimelineService.java
@@ -39,6 +39,7 @@ public class TimelineService implements TimelineUseCase {
             hasNext = checkHasNext(memories);
             nextMemoryRecordAt = getCursorRecordAt(memories);
             memories = getMemories(memories);
+            memories = memories.reversed();
         } else {
             memories =
                     memoryPersistencePort.findPrevMemoryByMemberId(
@@ -46,7 +47,6 @@ public class TimelineService implements TimelineUseCase {
             hasNext = checkHasNext(memories);
             nextMemoryRecordAt = getCursorRecordAt(memories);
             memories = getMemories(memories);
-            memories = memories.reversed();
         }
         return TimelineSlice.from(memories, nextMemoryRecordAt, hasNext);
     }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -110,6 +110,14 @@ public class MemoryRepository implements MemoryPersistencePort {
         List<MemoryEntity> memories =
                 queryFactory
                         .selectFrom(memory)
+                        .join(memory.member)
+                        .fetchJoin()
+                        .leftJoin(memory.pool)
+                        .fetchJoin()
+                        .leftJoin(memory.memoryDetail)
+                        .fetchJoin()
+                        .leftJoin(memory.strokes)
+                        .fetchJoin()
                         .where(
                                 memory.member.id.eq(memberId),
                                 ltCursorRecordAt(cursorRecordAt),
@@ -126,6 +134,14 @@ public class MemoryRepository implements MemoryPersistencePort {
         List<MemoryEntity> memories =
                 queryFactory
                         .selectFrom(memory)
+                        .join(memory.member)
+                        .fetchJoin()
+                        .leftJoin(memory.pool)
+                        .fetchJoin()
+                        .leftJoin(memory.memoryDetail)
+                        .fetchJoin()
+                        .leftJoin(memory.strokes)
+                        .fetchJoin()
                         .where(
                                 memory.member.id.eq(memberId),
                                 gtCursorRecordAt(cursorRecordAt),


### PR DESCRIPTION
## 🌱 관련 이슈

- close #239 

## 📌 작업 내용 및 특이사항
이전에 타임라인 리펙토링 같이 진행하는 과정에서 오류가 났습니다. 

- 타임라인 조회시 최신순이 아닌 생성 순으로 조회되던 오류 수정
- 타임라인의 N+1 문제 개선

## 📝 참고사항
수정 결과
![타임라인 정렬 오류](https://github.com/user-attachments/assets/259a92e5-74ee-4c6e-82b3-4a394b3ae513)


