### PR TITLE
feat: 기록 조회 시 이전, 이후 기록 id까지 함께 조회 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/domain/vo/MemoryInfo.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/vo/MemoryInfo.java
@@ -1,0 +1,5 @@
+package com.depromeet.memory.domain.vo;
+
+import com.depromeet.memory.domain.Memory;
+
+public record MemoryInfo(Memory memory, Long prevId, Long nextId, Boolean isMyMemory) {}

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
@@ -1,6 +1,7 @@
 package com.depromeet.memory.port.in.usecase;
 
 import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.domain.vo.MemoryInfo;
 import java.util.List;
 
 public interface GetMemoryUseCase {
@@ -10,9 +11,7 @@ public interface GetMemoryUseCase {
 
     int findOrderInMonth(Long memberId, Long memoryId, int month);
 
-    Memory findPrevMemoryById(Long memoryId);
-
-    Memory findNextMemoryById(Long memoryId);
-
     List<Memory> findByMemberId(Long memberId);
+
+    MemoryInfo findByIdWithPrevNext(Long requestMemberId, Long memoryId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -26,9 +26,9 @@ public interface MemoryPersistencePort {
 
     List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month);
 
-    Optional<Memory> findPrevMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
+    Long findPrevIdByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
 
-    Optional<Memory> findNextMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
+    Long findNextIdByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
 
     List<Memory> findByMemberId(Long memberId);
 

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -1,5 +1,7 @@
 package com.depromeet.memory.service;
 
+import static com.depromeet.memory.service.MemoryValidator.isMyMemory;
+
 import com.depromeet.exception.BadRequestException;
 import com.depromeet.exception.InternalServerException;
 import com.depromeet.exception.NotFoundException;
@@ -7,6 +9,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.domain.Stroke;
+import com.depromeet.memory.domain.vo.MemoryInfo;
 import com.depromeet.memory.port.in.command.CreateMemoryCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
 import com.depromeet.memory.port.in.usecase.CreateMemoryUseCase;
@@ -84,26 +87,21 @@ public class MemoryService
     }
 
     @Override
-    public Memory findPrevMemoryById(Long memoryId) {
-        Memory memory = findById(memoryId);
-        return memoryPersistencePort
-                .findPrevMemoryByRecordAtAndMemberId(
-                        memory.getRecordAt(), memory.getMember().getId())
-                .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND_PREV));
-    }
-
-    @Override
-    public Memory findNextMemoryById(Long memoryId) {
-        Memory memory = findById(memoryId);
-        return memoryPersistencePort
-                .findNextMemoryByRecordAtAndMemberId(
-                        memory.getRecordAt(), memory.getMember().getId())
-                .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND_NEXT));
-    }
-
-    @Override
     public List<Memory> findByMemberId(Long memberId) {
         return memoryPersistencePort.findByMemberId(memberId);
+    }
+
+    @Override
+    public MemoryInfo findByIdWithPrevNext(Long requestMemberId, Long memoryId) {
+        Memory memory = findById(memoryId);
+        Long prevId =
+                memoryPersistencePort.findPrevIdByRecordAtAndMemberId(
+                        memory.getRecordAt(), memory.getMember().getId());
+        Long nextId =
+                memoryPersistencePort.findNextIdByRecordAtAndMemberId(
+                        memory.getRecordAt(), memory.getMember().getId());
+        Boolean isMyMemory = isMyMemory(memory.getMember().getId(), requestMemberId);
+        return new MemoryInfo(memory, prevId, nextId, isMyMemory);
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
@@ -168,23 +168,27 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public Optional<Memory> findPrevMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+    public Long findPrevIdByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
         return data.stream()
                 .filter(
                         item ->
                                 item.getRecordAt().isBefore(recordAt)
                                         && item.getMember().getId().equals(memberId))
-                .max(Comparator.comparing(Memory::getRecordAt));
+                .max(Comparator.comparing(Memory::getRecordAt))
+                .map(Memory::getId)
+                .orElse(null);
     }
 
     @Override
-    public Optional<Memory> findNextMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+    public Long findNextIdByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
         return data.stream()
                 .filter(
                         item ->
                                 item.getRecordAt().isBefore(recordAt)
                                         && item.getMember().getId().equals(memberId))
-                .min(Comparator.comparing(Memory::getRecordAt));
+                .min(Comparator.comparing(Memory::getRecordAt))
+                .map(Memory::getId)
+                .orElse(null);
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -175,49 +175,23 @@ public class MemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public Optional<Memory> findPrevMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
-        MemoryEntity prevMemory =
-                queryFactory
-                        .selectFrom(memory)
-                        .join(memory.member, memberEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.pool, poolEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.memoryDetail, memoryDetailEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.strokes, strokeEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.images, imageEntity)
-                        .where(ltCursorRecordAt(recordAt), memberEq(memberId))
-                        .orderBy(memory.recordAt.desc())
-                        .fetchFirst();
-        if (prevMemory == null) {
-            return Optional.empty();
-        }
-        return Optional.of(prevMemory.toModel());
+    public Long findPrevIdByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+        return queryFactory
+                .select(memory.id)
+                .from(memory)
+                .where(ltCursorRecordAt(recordAt), memberEq(memberId))
+                .orderBy(memory.recordAt.desc())
+                .fetchFirst();
     }
 
     @Override
-    public Optional<Memory> findNextMemoryByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
-        MemoryEntity prevMemory =
-                queryFactory
-                        .selectFrom(memory)
-                        .join(memory.member, memberEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.pool, poolEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.memoryDetail, memoryDetailEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.strokes, strokeEntity)
-                        .fetchJoin()
-                        .leftJoin(memory.images, imageEntity)
-                        .where(gtCursorRecordAt(recordAt), memberEq(memberId))
-                        .orderBy(memory.recordAt.asc())
-                        .fetchFirst();
-        if (prevMemory == null) {
-            return Optional.empty();
-        }
-        return Optional.of(prevMemory.toModel());
+    public Long findNextIdByRecordAtAndMemberId(LocalDate recordAt, Long memberId) {
+        return queryFactory
+                .select(memory.id)
+                .from(memory)
+                .where(gtCursorRecordAt(recordAt), memberEq(memberId))
+                .orderBy(memory.recordAt.asc())
+                .fetchFirst();
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryApi.java
@@ -49,10 +49,4 @@ public interface MemoryApi {
             @LoginMember Long memberId,
             @RequestParam("year") Integer year,
             @RequestParam("month") Short month);
-
-    @Operation(summary = "수영 기록 record at 기준 이전 수영 기록 단일 조회")
-    ApiResponse<MemoryResponse> readPrev(@RequestParam("id") Long memoryId);
-
-    @Operation(summary = "수영 기록 record at 기준 다음 수영 기록 단일 조회")
-    ApiResponse<MemoryResponse> readNext(@RequestParam("id") Long memoryId);
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -77,16 +77,4 @@ public class MemoryController implements MemoryApi {
         CalendarResponse response = memoryFacade.getCalendar(memberId, year, month);
         return ApiResponse.success(MemorySuccessType.GET_CALENDAR_SUCCESS, response);
     }
-
-    @GetMapping("/prev")
-    public ApiResponse<MemoryResponse> readPrev(@RequestParam("id") Long memoryId) {
-        MemoryResponse response = memoryFacade.getPrevMemory(memoryId);
-        return ApiResponse.success(MemorySuccessType.GET_PREV_SUCCESS, response);
-    }
-
-    @GetMapping("/next")
-    public ApiResponse<MemoryResponse> readNext(@RequestParam("id") Long memoryId) {
-        MemoryResponse response = memoryFacade.getNextMemory(memoryId);
-        return ApiResponse.success(MemorySuccessType.GET_NEXT_SUCCESS, response);
-    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -6,6 +6,7 @@ import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.domain.Stroke;
+import com.depromeet.memory.domain.vo.MemoryInfo;
 import com.depromeet.pool.domain.Pool;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -22,11 +23,25 @@ import lombok.NoArgsConstructor;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class MemoryResponse {
     @Schema(
-            description = "memory PK",
-            example = "1",
+            description = "Memory PK",
+            example = "2",
             type = "long",
             requiredMode = Schema.RequiredMode.REQUIRED)
     private Long id;
+
+    @Schema(
+            description = "이전 Memory PK",
+            example = "1",
+            type = "long",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Long prevId;
+
+    @Schema(
+            description = "다음 Memory PK",
+            example = "3",
+            type = "long",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Long nextId;
 
     private MemberSimpleResponse member;
     private Pool pool;
@@ -109,6 +124,8 @@ public class MemoryResponse {
     @Builder
     public MemoryResponse(
             Long id,
+            Long prevId,
+            Long nextId,
             MemberSimpleResponse member,
             Pool pool,
             MemoryDetail memoryDetail,
@@ -137,6 +154,8 @@ public class MemoryResponse {
         }
 
         this.id = id;
+        this.prevId = prevId;
+        this.nextId = nextId;
         this.member = member;
         this.pool = pool;
         this.memoryDetail = getMemoryDetail(memoryDetail);
@@ -210,6 +229,30 @@ public class MemoryResponse {
                 .endTime(memory.getEndTime())
                 .lane(memory.getLane())
                 .diary(memory.getDiary())
+                .build();
+    }
+
+    public static MemoryResponse from(MemoryInfo memoryInfo) {
+        Memory memory = memoryInfo.memory();
+        MemberSimpleResponse memberSimple =
+                new MemberSimpleResponse(
+                        memory.getMember().getGoal(), memory.getMember().getNickname());
+        return MemoryResponse.builder()
+                .id(memory.getId())
+                .prevId(memoryInfo.prevId())
+                .nextId(memoryInfo.nextId())
+                .member(memberSimple)
+                .pool(memory.getPool())
+                .memoryDetail(memory.getMemoryDetail())
+                .type(memory.classifyType())
+                .strokes(memory.getStrokes())
+                .images(memory.getImages())
+                .recordAt(memory.getRecordAt())
+                .startTime(memory.getStartTime())
+                .endTime(memory.getEndTime())
+                .lane(memory.getLane())
+                .diary(memory.getDiary())
+                .isMyMemory(memoryInfo.isMyMemory())
                 .build();
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -255,25 +255,4 @@ public class MemoryResponse {
                 .isMyMemory(memoryInfo.isMyMemory())
                 .build();
     }
-
-    public static MemoryResponse from(Memory memory, Boolean isMyMemory) {
-        MemberSimpleResponse memberSimple =
-                new MemberSimpleResponse(
-                        memory.getMember().getGoal(), memory.getMember().getNickname());
-        return MemoryResponse.builder()
-                .id(memory.getId())
-                .member(memberSimple)
-                .pool(memory.getPool())
-                .memoryDetail(memory.getMemoryDetail())
-                .type(memory.classifyType())
-                .strokes(memory.getStrokes())
-                .images(memory.getImages())
-                .recordAt(memory.getRecordAt())
-                .startTime(memory.getStartTime())
-                .endTime(memory.getEndTime())
-                .lane(memory.getLane())
-                .diary(memory.getDiary())
-                .isMyMemory(isMyMemory)
-                .build();
-    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -1,6 +1,5 @@
 package com.depromeet.memory.facade;
 
-import static com.depromeet.memory.service.MemoryValidator.isMyMemory;
 import static com.depromeet.memory.service.MemoryValidator.validatePermission;
 
 import com.depromeet.followingLog.port.in.command.CreateFollowingMemoryCommand;
@@ -9,6 +8,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.Stroke;
+import com.depromeet.memory.domain.vo.MemoryInfo;
 import com.depromeet.memory.domain.vo.TimelineSlice;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
@@ -88,10 +88,9 @@ public class MemoryFacade {
         return MemoryReadUpdateResponse.from(memory);
     }
 
-    public MemoryResponse findById(Long memberId, Long memoryId) {
-        Memory memory = getMemoryUseCase.findById(memoryId);
-        Boolean isMyMemory = isMyMemory(memory.getMember().getId(), memberId);
-        return MemoryResponse.from(memory, isMyMemory);
+    public MemoryResponse findById(Long requestMemberId, Long memoryId) {
+        MemoryInfo memoryInfo = getMemoryUseCase.findByIdWithPrevNext(requestMemberId, memoryId);
+        return MemoryResponse.from(memoryInfo);
     }
 
     public TimelineSliceResponse getTimelineByMemberIdAndCursorAndDate(
@@ -109,15 +108,5 @@ public class MemoryFacade {
         List<Memory> calendarMemories =
                 calendarUseCase.getCalendarByYearAndMonth(memberId, yearMonth);
         return CalendarResponse.of(member, calendarMemories);
-    }
-
-    public MemoryResponse getPrevMemory(Long memoryId) {
-        Memory prevMemory = getMemoryUseCase.findPrevMemoryById(memoryId);
-        return MemoryResponse.from(prevMemory);
-    }
-
-    public MemoryResponse getNextMemory(Long memoryId) {
-        Memory nextMemory = getMemoryUseCase.findNextMemoryById(memoryId);
-        return MemoryResponse.from(nextMemory);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #242

## 📌 작업 내용 및 특이사항
- 기록 조회 API, 이전, 이후 기록 조회 API가 나뉘어 있는 것이 불필요하다는 피드백이 있었습니다.
- 기록 조회 API에 이전, 이후 기록의 id까지 추가하여 조회할 수 있도록 변경하였습니다.

## 📝 참고사항
- 데이터베이스
<img width="660" alt="Screenshot 2024-08-21 at 11 11 41" src="https://github.com/user-attachments/assets/3bfe90d7-6917-4abb-bf70-6f176a6bacea">

- 기준 기록 조회
<img width="841" alt="Screenshot 2024-08-21 at 11 15 23" src="https://github.com/user-attachments/assets/ae27b7cd-d97c-45a3-87c4-2e37ebfbacc3">
<img width="844" alt="Screenshot 2024-08-21 at 11 15 32" src="https://github.com/user-attachments/assets/5cc699a3-b43b-4574-8b8a-b5cd734bd15c">

- 이전 기록 조회
<img width="850" alt="Screenshot 2024-08-21 at 11 16 09" src="https://github.com/user-attachments/assets/cfe0b4c5-4101-48e9-93b2-d4af227b204f">
<img width="844" alt="Screenshot 2024-08-21 at 11 16 17" src="https://github.com/user-attachments/assets/c355e28c-a5be-44a5-91ab-274d2ea5cde4">

- 다음 기록 조회
<img width="863" alt="Screenshot 2024-08-21 at 11 14 06" src="https://github.com/user-attachments/assets/3275e3ec-1ae8-4d22-ab7e-2cd9dd72aa10">
<img width="844" alt="Screenshot 2024-08-21 at 11 14 18" src="https://github.com/user-attachments/assets/002f57dd-205f-4e8a-b653-9ddbb2c07596">