### PR TITLE
fix: swagger에서 팔로잉 소식 조회 시 is~로 시작하는 필드명에서 is가 빠져서 보이는 문제 해결

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/followingLog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followingLog/dto/response/FollowingLogMemoryResponse.java
@@ -1,6 +1,7 @@
 package com.depromeet.followingLog.dto.response;
 
 import com.depromeet.followingLog.domain.FollowingMemoryLog;
+import com.depromeet.member.domain.Member;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.Stroke;
 import com.depromeet.memory.dto.response.StrokeResponse;
@@ -11,136 +12,96 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class FollowingLogMemoryResponse {
-    @Schema(
-            description = "member PK(팔로잉 member PK)",
-            example = "1",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private Long memberId;
-
-    @Schema(
-            description = "member 이름(팔로잉 이름)",
-            example = "김민석",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private String memberNickname;
-
-    @Schema(description = "memory PK", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-    private Long memoryId;
-
-    @Schema(
-            description = "수영기록 등록 날짜",
-            example = "2024-07-31",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private String recordAt;
-
-    @Schema(
-            description = "수영 시작 시간",
-            example = "11:00",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private String startTime;
-
-    @Schema(
-            description = "수영 시작 시간",
-            example = "12:00",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private String endTime;
-
-    @Schema(
-            description = "수영장 레인 길이",
-            example = "25",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private Short lane;
-
-    @Schema(
-            description = "수영 기록 일기",
-            example = "오늘 수영을 열심히 했다",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private String diary;
-
-    @Schema(
-            description = "총 수영 거리",
-            example = "175",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private Integer totalDistance;
-
-    @Schema(description = "달성 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
-    private boolean isAchieved;
-
-    @Schema(
-            description = "소모한 칼로리",
-            example = "100",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private Integer kcal;
-
-    @Schema(
-            description = "영법 타입(NORMAL, SINGLE, MULTI)",
-            example = "NORMAL",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private String type;
-
-    @Schema(description = "영법별 거리 리스트", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private List<StrokeResponse> strokes;
-
-    @Schema(description = "이미지", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    private String imageUrl;
-
-    @Schema(
-            description = "팔로잉 소식 생성 시간",
-            example = "2024-08-16 00:00:00",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime createdAt;
-
-    @Schema(
-            description = "팔로잉 소식 최신 유무",
-            example = "false",
-            requiredMode = Schema.RequiredMode.REQUIRED)
-    private boolean isRecentNews;
-
+public record FollowingLogMemoryResponse(
+        @Schema(
+                        description = "member PK(팔로잉 member PK)",
+                        example = "1",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                Long memberId,
+        @Schema(
+                        description = "member 이름(팔로잉 이름)",
+                        example = "김민석",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                String memberNickname,
+        @Schema(
+                        description = "member 프로필 url",
+                        example = "https://presignedUrl/image.webp",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String memberProfileUrl,
+        @Schema(
+                        description = "memory PK",
+                        example = "1",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                Long memoryId,
+        @Schema(
+                        description = "수영기록 등록 날짜",
+                        example = "2024-07-31",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                String recordAt,
+        @Schema(
+                        description = "수영 시작 시간",
+                        example = "11:00",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                String startTime,
+        @Schema(
+                        description = "수영 시작 시간",
+                        example = "12:00",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                String endTime,
+        @Schema(
+                        description = "수영장 레인 길이",
+                        example = "25",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                Short lane,
+        @Schema(
+                        description = "수영 기록 일기",
+                        example = "오늘 수영을 열심히 했다",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String diary,
+        @Schema(
+                        description = "총 수영 거리",
+                        example = "175",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                Integer totalDistance,
+        @Schema(
+                        description = "달성 여부",
+                        example = "false",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                boolean isAchieved,
+        @Schema(
+                        description = "소모한 칼로리",
+                        example = "100",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                Integer kcal,
+        @Schema(
+                        description = "영법 타입(NORMAL, SINGLE, MULTI)",
+                        example = "NORMAL",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                String type,
+        @Schema(description = "영법별 거리 리스트", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                List<StrokeResponse> strokes,
+        @Schema(description = "이미지", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String imageUrl,
+        @Schema(
+                        description = "팔로잉 소식 생성 시간",
+                        example = "2024-08-16 00:00:00",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+                LocalDateTime createdAt,
+        @Schema(
+                        description = "팔로잉 소식 최신 유무",
+                        example = "false",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                boolean isRecentNews) {
     @Builder
-    public FollowingLogMemoryResponse(
-            Long memberId,
-            String memberNickname,
-            Long memoryId,
-            String recordAt,
-            String startTime,
-            String endTime,
-            Short lane,
-            String diary,
-            Integer totalDistance,
-            boolean isAchieved,
-            Integer kcal,
-            String type,
-            List<StrokeResponse> strokes,
-            String imageUrl,
-            LocalDateTime createdAt,
-            boolean isRecentNews) {
-        this.memberId = memberId;
-        this.memberNickname = memberNickname;
-        this.memoryId = memoryId;
-        this.recordAt = recordAt;
-        this.startTime = startTime;
-        this.endTime = endTime;
-        this.lane = lane;
-        this.diary = diary;
-        this.totalDistance = totalDistance;
-        this.isAchieved = isAchieved;
-        this.kcal = kcal;
-        this.type = type;
-        this.strokes = strokes;
-        this.imageUrl = imageUrl;
-        this.createdAt = createdAt;
-        this.isRecentNews = isRecentNews;
-    }
+    public FollowingLogMemoryResponse {}
 
     public static FollowingLogMemoryResponse toFollowingLogMemoryResponse(
-            FollowingMemoryLog followingMemoryLog, LocalDateTime lastViewedFollowingLogAt) {
+            FollowingMemoryLog followingMemoryLog,
+            LocalDateTime lastViewedFollowingLogAt,
+            String profileImageOrigin) {
         boolean isRecentNews = checkIsRecentLog(followingMemoryLog, lastViewedFollowingLogAt);
         Memory memory = followingMemoryLog.getMemory();
         Integer totalDistance = memory.calculateTotalDistance();
@@ -148,6 +109,8 @@ public class FollowingLogMemoryResponse {
         return FollowingLogMemoryResponse.builder()
                 .memberId(followingMemoryLog.getMember().getId())
                 .memberNickname(followingMemoryLog.getMember().getNickname())
+                .memberProfileUrl(
+                        getMemberProfileUrl(followingMemoryLog.getMember(), profileImageOrigin))
                 .memoryId(memory.getId())
                 .recordAt(memory.getRecordAt().toString())
                 .startTime(memory.parseStartTime())
@@ -162,6 +125,13 @@ public class FollowingLogMemoryResponse {
                 .createdAt(followingMemoryLog.getCreatedAt())
                 .isRecentNews(isRecentNews)
                 .build();
+    }
+
+    private static String getMemberProfileUrl(Member member, String profileImageOrigin) {
+        if (member.getProfileImageUrl() != null) {
+            return profileImageOrigin + "/" + member.getProfileImageUrl();
+        }
+        return null;
     }
 
     private static boolean isAchieved(Integer totalDistance, int goal) {

--- a/module-presentation/src/main/java/com/depromeet/followingLog/dto/response/FollowingLogSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followingLog/dto/response/FollowingLogSliceResponse.java
@@ -44,13 +44,17 @@ public class FollowingLogSliceResponse {
     }
 
     public static FollowingLogSliceResponse toFollowingLogSliceResponse(
-            FollowingLogSlice followingLogSlice, LocalDateTime lastViewedFollowingLogAt) {
+            FollowingLogSlice followingLogSlice,
+            LocalDateTime lastViewedFollowingLogAt,
+            String profileImageOrigin) {
         List<FollowingLogMemoryResponse> contents =
                 followingLogSlice.getContents().stream()
                         .map(
                                 followingMemoryLog ->
                                         FollowingLogMemoryResponse.toFollowingLogMemoryResponse(
-                                                followingMemoryLog, lastViewedFollowingLogAt))
+                                                followingMemoryLog,
+                                                lastViewedFollowingLogAt,
+                                                profileImageOrigin))
                         .toList();
         return FollowingLogSliceResponse.builder()
                 .content(contents)

--- a/module-presentation/src/main/java/com/depromeet/followingLog/facade/FollowingLogFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/followingLog/facade/FollowingLogFacade.java
@@ -7,6 +7,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.port.in.usecase.MemberUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,13 +19,18 @@ public class FollowingLogFacade {
     private final MemberUpdateUseCase memberUpdateUseCase;
     private final FollowingMemoryLogUseCase followingMemoryLogUseCase;
 
+    @Value("${cloud-front.domain}")
+    private String profileImageOrigin;
+
     public FollowingLogSliceResponse getLogsByMemberIdAndCursorId(Long memberId, Long cursorId) {
         FollowingLogSlice followingLogSlice =
                 followingMemoryLogUseCase.findLogsByMemberIdAndCursorId(memberId, cursorId);
         Member member = memberUseCase.findById(memberId);
         FollowingLogSliceResponse followingLogSliceResponse =
                 FollowingLogSliceResponse.toFollowingLogSliceResponse(
-                        followingLogSlice, member.getLastViewedFollowingLogAt());
+                        followingLogSlice,
+                        member.getLastViewedFollowingLogAt(),
+                        profileImageOrigin);
         memberUpdateUseCase.updateLatestViewedFollowingLogAt(memberId);
 
         return followingLogSliceResponse;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #244 

## 📌 작업 내용 및 특이사항
- 스웨거에서 팔로잉 소식 조회 시 코드와 달리 is로 시작하는 필드명에서 is가 빠져서 보이는 이슈 발견

main 브랜치의 FollowingMemoryLogResponse의 isAchieved, isRecentNews의 필드명
![main브랜치의 코드](https://github.com/user-attachments/assets/9db30f61-5ec9-4d8c-989d-8f706ef6118e)

production 서버 스웨거 화면의 `/news` response 화면
![swagger 화면](https://github.com/user-attachments/assets/0f452fc0-a2ff-4ad0-8a53-427d2b843c33)

  - FollowingMemoryLogResponse를 class -> record 로 변경하여 해결
- 사용자 프로필 이미지 url 필드 추가


## 📝 참고사항
- 수정 후 팔로잉 소식 조회 결과
![수정 완료](https://github.com/user-attachments/assets/01c524de-3c94-45af-9fb6-4909013f2d96)

