### PR TITLE
feat: 응원 생성 여부 검증 API 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/GetReactionUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/GetReactionUseCase.java
@@ -10,4 +10,6 @@ public interface GetReactionUseCase {
     ReactionPage getDetailReactions(Long memberId, Long memoryId, Long cursorId);
 
     Long getDetailReactionsCount(Long memoryId);
+
+    List<Reaction> getReactionsByMemberAndMemory(Long memberId, Long memoryId);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
@@ -20,4 +20,6 @@ public interface ReactionPersistencePort {
     void deleteById(Long reactionId);
 
     void deleteByMemberId(Long memberId);
+
+    List<Reaction> getPureReactionsByMemberAndMemory(Long memberId, Long memoryId);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
@@ -100,7 +100,7 @@ public class ReactionService
 
     @Override
     public List<Reaction> getReactionsByMemberAndMemory(Long memberId, Long memoryId) {
-        return getAllByMemberAndMemory(memberId, memoryId);
+        return reactionPersistencePort.getPureReactionsByMemberAndMemory(memberId, memoryId);
     }
 
     private boolean isOverMaximumCreationLimit(List<Reaction> reactions) {

--- a/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
@@ -98,6 +98,11 @@ public class ReactionService
         return reactionPersistencePort.getAllCountByMemoryId(memoryId);
     }
 
+    @Override
+    public List<Reaction> getReactionsByMemberAndMemory(Long memberId, Long memoryId) {
+        return getAllByMemberAndMemory(memberId, memoryId);
+    }
+
     private boolean isOverMaximumCreationLimit(List<Reaction> reactions) {
         return !reactions.isEmpty() && reactions.size() >= MAXIMUM_REACTION_NUMBER;
     }

--- a/module-independent/src/main/java/com/depromeet/type/reaction/ReactionSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/reaction/ReactionSuccessType.java
@@ -5,7 +5,8 @@ import com.depromeet.type.SuccessType;
 public enum ReactionSuccessType implements SuccessType {
     POST_REACTION_SUCCESS("REACTION_1", "응원 등록에 성공하였습니다"),
     GET_MEMORY_REACTIONS_SUCCESS("REACTION_2", "응원 목록 조회에 성공하였습니다"),
-    GET_DETAIL_REACTIONS_SUCCESS("REACTION_3", "응원 상세 조회에 성공하였습니다");
+    GET_DETAIL_REACTIONS_SUCCESS("REACTION_3", "응원 상세 조회에 성공하였습니다"),
+    VALIDATE_REACTION_SUCCESS("REACTION_4", "응원 생성 여부 검증에 성공하였습니다");
 
     private final String code;
     private final String message;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
@@ -43,6 +43,17 @@ public class ReactionRepository implements ReactionPersistencePort {
     }
 
     @Override
+    public List<Reaction> getPureReactionsByMemberAndMemory(Long memberId, Long memoryId) {
+        List<ReactionEntity> reactionEntities =
+                queryFactory
+                        .selectFrom(reactionEntity)
+                        .where(memberEq(memberId), memoryEq(memoryId))
+                        .fetch();
+
+        return reactionEntities.stream().map(ReactionEntity::pureToModel).toList();
+    }
+
+    @Override
     public List<Reaction> getAllByMemoryId(Long memoryId) {
         return queryFactory
                 .selectFrom(reactionEntity)

--- a/module-presentation/src/main/java/com/depromeet/reaction/annotation/SingleEmojiCheck.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/annotation/SingleEmojiCheck.java
@@ -1,0 +1,19 @@
+package com.depromeet.reaction.annotation;
+
+import com.depromeet.reaction.validator.SingleEmojiValidator;
+import jakarta.validation.Constraint;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = SingleEmojiValidator.class)
+public @interface SingleEmojiCheck {
+    String message() default "이모지 한 개를 입력해야 합니다";
+
+    Class[] groups() default {};
+
+    Class[] payload() default {};
+}

--- a/module-presentation/src/main/java/com/depromeet/reaction/api/ReactionApi.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/api/ReactionApi.java
@@ -5,6 +5,7 @@ import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.reaction.dto.request.ReactionCreateRequest;
 import com.depromeet.reaction.dto.response.MemoryReactionResponse;
 import com.depromeet.reaction.dto.response.PagingReactionResponse;
+import com.depromeet.reaction.dto.response.ValidateReactionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -20,18 +21,22 @@ public interface ReactionApi {
     ApiResponse<?> create(
             @LoginMember Long memberId, @Valid @RequestBody ReactionCreateRequest request);
 
+    @Operation(summary = "응원 가능 여부 확인")
+    ApiResponse<ValidateReactionResponse> validate(
+            @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId);
+
     @Operation(summary = "수영 상세 기록 내 가로 스크롤 응원 조회")
-    ApiResponse<MemoryReactionResponse> read(@PathVariable(value = "memoryId") Long memoryId);
+    ApiResponse<MemoryReactionResponse> read(@PathVariable("memoryId") Long memoryId);
 
     @Operation(summary = "응원 전체 상세 조회")
     ApiResponse<PagingReactionResponse> read(
             @LoginMember Long memberId,
-            @PathVariable(value = "memoryId") Long memoryId,
+            @PathVariable("memoryId") Long memoryId,
             @Parameter(description = "다음 조회를 위한 커서 ID", example = "21")
                     @RequestParam(value = "cursorId", required = false)
                     Long cursorId);
 
     @Operation(summary = "응원 삭제")
     ResponseEntity<Void> delete(
-            @LoginMember Long memberId, @PathVariable(value = "reactionId") Long reactionId);
+            @LoginMember Long memberId, @PathVariable("reactionId") Long reactionId);
 }

--- a/module-presentation/src/main/java/com/depromeet/reaction/api/ReactionController.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/api/ReactionController.java
@@ -6,6 +6,7 @@ import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.reaction.dto.request.ReactionCreateRequest;
 import com.depromeet.reaction.dto.response.MemoryReactionResponse;
 import com.depromeet.reaction.dto.response.PagingReactionResponse;
+import com.depromeet.reaction.dto.response.ValidateReactionResponse;
 import com.depromeet.reaction.facade.ReactionFacade;
 import com.depromeet.type.reaction.ReactionSuccessType;
 import jakarta.validation.Valid;
@@ -33,9 +34,17 @@ public class ReactionController implements ReactionApi {
     }
 
     @Logging(item = "Reaction", action = "GET")
+    @GetMapping("/memory/{memoryId}/reaction/eligibility")
+    public ApiResponse<ValidateReactionResponse> validate(
+            @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId) {
+        return ApiResponse.success(
+                ReactionSuccessType.VALIDATE_REACTION_SUCCESS,
+                reactionFacade.validate(memberId, memoryId));
+    }
+
+    @Logging(item = "Reaction", action = "GET")
     @GetMapping("/memory/{memoryId}/reactions")
-    public ApiResponse<MemoryReactionResponse> read(
-            @PathVariable(value = "memoryId") Long memoryId) {
+    public ApiResponse<MemoryReactionResponse> read(@PathVariable("memoryId") Long memoryId) {
         return ApiResponse.success(
                 ReactionSuccessType.GET_MEMORY_REACTIONS_SUCCESS,
                 reactionFacade.getReactionsOfMemory(memoryId));
@@ -45,7 +54,7 @@ public class ReactionController implements ReactionApi {
     @GetMapping("/memory/{memoryId}/reactions/detail")
     public ApiResponse<PagingReactionResponse> read(
             @LoginMember Long memberId,
-            @PathVariable(value = "memoryId") Long memoryId,
+            @PathVariable("memoryId") Long memoryId,
             @RequestParam(value = "cursorId", required = false) Long cursorId) {
         return ApiResponse.success(
                 ReactionSuccessType.GET_DETAIL_REACTIONS_SUCCESS,
@@ -55,7 +64,7 @@ public class ReactionController implements ReactionApi {
     @Logging(item = "Reaction", action = "DELETE")
     @DeleteMapping("/memory/reaction/{reactionId}")
     public ResponseEntity<Void> delete(
-            @LoginMember Long memberId, @PathVariable(value = "reactionId") Long reactionId) {
+            @LoginMember Long memberId, @PathVariable("reactionId") Long reactionId) {
         reactionFacade.deleteById(memberId, reactionId);
         return ResponseEntity.noContent().build();
     }

--- a/module-presentation/src/main/java/com/depromeet/reaction/dto/request/ReactionCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/dto/request/ReactionCreateRequest.java
@@ -1,9 +1,9 @@
 package com.depromeet.reaction.dto.request;
 
+import com.depromeet.reaction.annotation.SingleEmojiCheck;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 public record ReactionCreateRequest(
         @Schema(description = "기록 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -11,7 +11,7 @@ public record ReactionCreateRequest(
                 Long memoryId,
         @Schema(description = "이모지", example = "🦭", requiredMode = Schema.RequiredMode.REQUIRED)
                 @NotBlank
-                @Size(max = 2)
+                @SingleEmojiCheck
                 String emoji,
         @Schema(
                         description = "코멘트",

--- a/module-presentation/src/main/java/com/depromeet/reaction/dto/response/ValidateReactionResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/dto/response/ValidateReactionResponse.java
@@ -1,0 +1,7 @@
+package com.depromeet.reaction.dto.response;
+
+public record ValidateReactionResponse(boolean isRegistrable) {
+    public static ValidateReactionResponse from(boolean isRegistrable) {
+        return new ValidateReactionResponse(isRegistrable);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/reaction/dto/response/ValidateReactionResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/dto/response/ValidateReactionResponse.java
@@ -1,6 +1,10 @@
 package com.depromeet.reaction.dto.response;
 
-public record ValidateReactionResponse(boolean isRegistrable) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ValidateReactionResponse(
+        @Schema(description = "응원 등록 가능 여부", requiredMode = Schema.RequiredMode.REQUIRED)
+                boolean isRegistrable) {
     public static ValidateReactionResponse from(boolean isRegistrable) {
         return new ValidateReactionResponse(isRegistrable);
     }

--- a/module-presentation/src/main/java/com/depromeet/reaction/facade/ReactionFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/facade/ReactionFacade.java
@@ -54,14 +54,9 @@ public class ReactionFacade {
         List<Reaction> reactionDomains =
                 getReactionUseCase.getReactionsByMemberAndMemory(memberId, memoryId);
 
-        boolean isRegistrable = false;
-        if (reactionDomains != null && reactionDomains.isEmpty()) {
-            Memory memory = getMemoryUseCase.findByIdWithMember(memoryId);
-            if (!memory.getMember().getId().equals(memberId)) {
-                isRegistrable = true;
-            }
-        } else if (reactionDomains != null && reactionDomains.size() < MAXIMUM_REACTION_NUMBER) {
-            isRegistrable = true;
+        boolean isRegistrable = true;
+        if (reactionDomains != null && reactionDomains.size() >= MAXIMUM_REACTION_NUMBER) {
+            isRegistrable = false;
         }
         return ValidateReactionResponse.from(isRegistrable);
     }

--- a/module-presentation/src/main/java/com/depromeet/reaction/validator/SingleEmojiValidator.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/validator/SingleEmojiValidator.java
@@ -1,0 +1,25 @@
+package com.depromeet.reaction.validator;
+
+import com.depromeet.reaction.annotation.SingleEmojiCheck;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.text.BreakIterator;
+
+public class SingleEmojiValidator implements ConstraintValidator<SingleEmojiCheck, String> {
+    @Override
+    public boolean isValid(String text, ConstraintValidatorContext constraintValidatorContext) {
+        BreakIterator it = BreakIterator.getCharacterInstance();
+        it.setText(text);
+        int count = 0;
+        while (it.current() < text.length()) {
+            if (Character.isEmoji(text.codePointAt(it.current()))) {
+                ++count;
+            } else {
+                return false;
+            }
+            it.next();
+        }
+
+        return count == 1;
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #248 

## 📌 작업 내용 및 특이사항
- 응원 생성 여부 검증 API를 구현하였습니다.
- 자신의 기록일 때와 응원이 이미 3개가 등록되어 있을 경우가 false이고 나머지는 true입니다.
- 또한 기존 응원 등록 시 이모지 필드 검증을 Length로 하였는데 이를 Custom Validator로 검증하는 로직을 추가하였습니다. 기존 길이 방식의 검증은 이모지마다 길이가 다르므로 검증이 실패하는 경우가 생겨 추가하였습니다.
- Swagger 접속 시 항상 No Static Resource favicon.ico를 제거하기 위해 favicon.ico 파일을 추가하였습니다.

## 📝 참고사항
`[타인의 기록이고 등록한 응원의 개수가 3 미만일 때]`
<img width="806" alt="image" src="https://github.com/user-attachments/assets/3e4a4a28-ae5c-43fc-bd54-5bc2a9234f1b">

`[자신의 기록이거나 응원의 개수가 이미 3개가 되었을 때]`
<img width="811" alt="image" src="https://github.com/user-attachments/assets/a3789536-0d6e-4642-a75b-105ea2134a0f">
