### PR TITLE
feat: 팔로잉 여부 확인 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
@@ -23,4 +23,6 @@ public interface FollowUseCase {
     FriendCount countFriendByMemberId(Long memberId);
 
     void deleteByMemberId(Long memberId);
+
+    Boolean isFollowing(Long memberId, Long targetMemberId);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -74,4 +74,14 @@ public class FollowService implements FollowUseCase {
     public void deleteByMemberId(Long memberId) {
         friendPersistencePort.deleteByMemberId(memberId);
     }
+
+    @Override
+    public Boolean isFollowing(Long memberId, Long targetMemberId) {
+        if (memberId.equals(targetMemberId)) {
+            throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
+        }
+        return friendPersistencePort
+                .findByMemberIdAndFollowingId(memberId, targetMemberId)
+                .isPresent();
+    }
 }

--- a/module-independent/src/main/java/com/depromeet/type/friend/FollowSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/friend/FollowSuccessType.java
@@ -8,7 +8,8 @@ public enum FollowSuccessType implements SuccessType {
     GET_FOLLOWINGS_SUCCESS("FOLLOW_3", "팔로잉 리스트 조회에 성공하였습니다"),
     GET_FOLLOWERS_SUCCESS("FOLLOW_4", "팔로워 리스트 조회에 성공하였습니다"),
     GET_FOLLOWER_FOLLOWING_COUNT_SUCCESS("FOLLOW_5", "팔로워/팔로잉 숫자 조회에 성공하였습니다"),
-    GET_FOLLOWING_SUMMARY_SUCCESS("FOLLOW_6", "팔로잉 요약 정보 조회에 성공하였습니다");
+    GET_FOLLOWING_SUMMARY_SUCCESS("FOLLOW_6", "팔로잉 요약 정보 조회에 성공하였습니다"),
+    CHECK_FOLLOWING_SUCCESS("FOLLOW_7", "팔로잉 여부 조회에 성공하였습니다");
 
     private final String code;
     private final String message;

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
@@ -2,13 +2,11 @@ package com.depromeet.friend.api;
 
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.friend.dto.request.FollowRequest;
-import com.depromeet.friend.dto.response.FollowSliceResponse;
-import com.depromeet.friend.dto.response.FollowerResponse;
-import com.depromeet.friend.dto.response.FollowingResponse;
-import com.depromeet.friend.dto.response.FollowingSummaryResponse;
+import com.depromeet.friend.dto.response.*;
 import com.depromeet.member.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -30,4 +28,8 @@ public interface FollowApi {
 
     @Operation(summary = "팔로잉 소식 페이지에 사용할 팔로잉 유저 목록 조회")
     ApiResponse<FollowingSummaryResponse> findFollowingSummary(@LoginMember Long memberId);
+
+    @Operation(summary = "팔로잉 여부 조회")
+    ApiResponse<IsFollowingResponse> checkFollowing(
+            @LoginMember Long memberId, @PathVariable("memberId") Long targetMemberId);
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
@@ -3,10 +3,7 @@ package com.depromeet.friend.api;
 import com.depromeet.config.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.friend.dto.request.FollowRequest;
-import com.depromeet.friend.dto.response.FollowSliceResponse;
-import com.depromeet.friend.dto.response.FollowerResponse;
-import com.depromeet.friend.dto.response.FollowingResponse;
-import com.depromeet.friend.dto.response.FollowingSummaryResponse;
+import com.depromeet.friend.dto.response.*;
 import com.depromeet.friend.facade.FollowFacade;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.type.friend.FollowSuccessType;
@@ -56,5 +53,13 @@ public class FollowController implements FollowApi {
     public ApiResponse<FollowingSummaryResponse> findFollowingSummary(@LoginMember Long memberId) {
         FollowingSummaryResponse response = followFacade.findFollowingSummary(memberId);
         return ApiResponse.success(FollowSuccessType.GET_FOLLOWING_SUMMARY_SUCCESS, response);
+    }
+
+    @GetMapping("/{memberId}")
+    @Logging(item = "Follower/Following", action = "GET")
+    public ApiResponse<IsFollowingResponse> checkFollowing(
+            @LoginMember Long memberId, @PathVariable("memberId") Long targetMemberId) {
+        IsFollowingResponse response = followFacade.isFollowing(memberId, targetMemberId);
+        return ApiResponse.success(FollowSuccessType.CHECK_FOLLOWING_SUCCESS, response);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
@@ -1,0 +1,16 @@
+package com.depromeet.friend.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record IsFollowingResponse(
+        @NotNull
+                @Schema(
+                        description = "팔로잉 여부",
+                        example = "true",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                Boolean isFollowing) {
+    public static IsFollowingResponse toIsFollowingResponse(Boolean isFollowing) {
+        return new IsFollowingResponse(isFollowing);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -4,10 +4,7 @@ import com.depromeet.friend.domain.vo.FollowSlice;
 import com.depromeet.friend.domain.vo.Follower;
 import com.depromeet.friend.domain.vo.Following;
 import com.depromeet.friend.dto.request.FollowRequest;
-import com.depromeet.friend.dto.response.FollowSliceResponse;
-import com.depromeet.friend.dto.response.FollowerResponse;
-import com.depromeet.friend.dto.response.FollowingResponse;
-import com.depromeet.friend.dto.response.FollowingSummaryResponse;
+import com.depromeet.friend.dto.response.*;
 import com.depromeet.friend.port.in.FollowUseCase;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
@@ -51,5 +48,10 @@ public class FollowFacade {
 
         return FollowingSummaryResponse.toFollowingSummaryResponse(
                 followingCount, followings, profileImageOrigin);
+    }
+
+    public IsFollowingResponse isFollowing(Long memberId, Long targetMemberId) {
+        Boolean isFollowing = followUseCase.isFollowing(memberId, targetMemberId);
+        return IsFollowingResponse.toIsFollowingResponse(isFollowing);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #252

## 📌 작업 내용 및 특이사항
- 팔로잉 여부를 확인할 수 있는 기능을 구현합니다.
- 팔로우 팔로잉은 마이페이지 외의 페이지에서도 사용될 예정이며,
- 마이페이지에 팔로잉 팔로우 변경을 1개를 위해 모든 데이터가 refetch 되어 데이터를 다시 받는 게 비효율적이라는 의견에 따라
- 마이페이지 API에 데이터를 추가하지 않고 API를 분리하게 되었습니다.

## 📝 참고사항
- 테스트 대상 데이터 입니다.
- 회원은 총 세 명이 있습니다.
<img width="210" alt="Screenshot 2024-08-23 at 18 23 37" src="https://github.com/user-attachments/assets/3990d5b1-e230-4f26-80b3-e9937b7e8065">

- 팔로우/팔로잉 상태입니다.
<img width="347" alt="Screenshot 2024-08-23 at 18 23 48" src="https://github.com/user-attachments/assets/e80e3f65-e12e-45f8-99a4-a6452e7cf8f8">

![IMG_2068](https://github.com/user-attachments/assets/e5d1bccd-ae84-4475-87d7-bd93030c230c)

- 2번 회원이 4번 회원의 마이페이지에 들어간 경우
<img width="850" alt="Screenshot 2024-08-23 at 18 24 02" src="https://github.com/user-attachments/assets/fac3f138-e332-4958-928d-14bace20b0fc">

- 4번 회원이 2번 회원의 마이페이지에 들어간 경우
<img width="843" alt="Screenshot 2024-08-23 at 18 24 15" src="https://github.com/user-attachments/assets/1096a438-1c0a-4000-a603-2ee0fafe5631">

- 4번 회원이 3번 회원의 마이페이지에 들어간 경우
<img width="841" alt="Screenshot 2024-08-23 at 18 24 20" src="https://github.com/user-attachments/assets/0922da4f-0372-4e54-a535-26bcae53a885">

- 2번 회원이 2번 회원의 마이페이지에 들어간 경우 (자기 자신)
<img width="839" alt="Screenshot 2024-08-23 at 18 22 24" src="https://github.com/user-attachments/assets/3b785c79-25c0-4848-b077-774a3116a4f7">