### PR TITLE
feat: 동일 API 동시 요청 제한 디바운스 구현

### DIFF
--- a/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/common/CommonErrorType.java
@@ -15,7 +15,8 @@ public enum CommonErrorType implements ErrorType {
     RUNTIME("COMMON_10", "런타임 예외가 발생했습니다"),
     IO("COMMON_11", "I/O 예외가 발생했습니다"),
     NULL("COMMON_12", "객체가 null 인 상태에서 접근하였습니다"),
-    NO_SUCH_ELEMENT("COMMON_13", "요소가 존재하지 않습니다");
+    NO_SUCH_ELEMENT("COMMON_13", "요소가 존재하지 않습니다"),
+    TOO_MANY_REQUESTS("COMMON_14", "요청이 너무 많습니다");
 
     private final String code;
     private final String message;

--- a/module-presentation/src/main/java/com/depromeet/common/DuplicateRequestAspect.java
+++ b/module-presentation/src/main/java/com/depromeet/common/DuplicateRequestAspect.java
@@ -1,0 +1,57 @@
+package com.depromeet.common;
+
+import static java.util.concurrent.TimeUnit.*;
+
+import com.depromeet.exception.BaseException;
+import com.depromeet.type.common.CommonErrorType;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+public class DuplicateRequestAspect {
+    private Set<String> requestSet = Collections.synchronizedSet(new HashSet<>());
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+    @Pointcut("within(*..*Controller)")
+    public void onRequest() {}
+
+    @Around("onRequest()")
+    public Object duplicateRequestCheck(ProceedingJoinPoint joinPoint) throws Throwable {
+        HttpServletRequest request =
+                ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+                        .getRequest();
+        String httpMethod = request.getMethod();
+
+        if ("GET".equalsIgnoreCase(httpMethod)) {
+            return joinPoint.proceed();
+        }
+
+        String requestId = joinPoint.getSignature().toLongString();
+        if (requestSet.contains(requestId)) {
+            handleDuplicateRequest();
+        }
+        requestSet.add(requestId);
+        try {
+            return joinPoint.proceed();
+        } finally {
+            scheduler.schedule(() -> requestSet.remove(requestId), 1, SECONDS);
+        }
+    }
+
+    private void handleDuplicateRequest() {
+        throw new BaseException(CommonErrorType.TOO_MANY_REQUESTS, HttpStatus.TOO_MANY_REQUESTS);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #262 

## 📌 작업 내용 및 특이사항
- 자원 생성 및 업데이트 시 동시 요청이 모두 처리되어 동일 자원이 여러개 생성되거나 비효율적인 업데이트 쿼리가 남발되는 것을 방지하기 위해 디바운스 기능을 구현하였습니다.
- AOP를 이용하여 Controller가 실행될 때 같은 요청에 대한 id를 `synchronizedSet`에 저장합니다.
- 만약 동일 요청이 발생 시 synchronizedSet에 자신의 요청 id가 존재하지 않으면 정상적으로 처리되고 존재하면 요청이 처리되지 않고 `429 Too Many Requests`를 반환합니다.
- 동일 요청을 디바운스하는 주기는 `1초`입니다. 이후 변경이 필요할 시 변경해도 됩니다.
- GET 요청은 동시 요청이 여러번 발생해도 막지 않습니다.

## 📝 참고사항
`[기존 응원 생성 API를 한번에 여러번 호출할 경우(쓰레드 요청 간격 0)]`
<img width="631" alt="스크린샷 2024-08-25 오전 1 10 35" src="https://github.com/user-attachments/assets/643d0293-745d-42c7-8943-8ff7532a4514">

`[변경된 방식으로 여러번 호출할 경우(쓰레드 요청 간격 0) - 하나만 성공하고 나머지는 실패]`
<img width="636" alt="스크린샷 2024-08-25 오전 1 44 52" src="https://github.com/user-attachments/assets/5ede9ae1-bff6-4c0e-be3d-8279febaba4c">

<img width="610" alt="스크린샷 2024-08-25 오전 1 45 00" src="https://github.com/user-attachments/assets/2915e990-863d-4ef7-af9d-611ff2baddd9">
