### PR TITLE
fix: 회원 정보 수정 시 필드 Blank 체크 추가, 기본 프로필 이미지 기능 추가

### DIFF
--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -126,10 +126,10 @@ public class MemberEntity {
     }
 
     public MemberEntity update(UpdateMemberCommand command) {
-        if (!command.nickname().isBlank()) {
+        if (command.nickname() != null && !command.nickname().isBlank()) {
             this.nickname = command.nickname();
         }
-        if (!command.introduction().isBlank()) {
+        if (command.introduction() != null && !command.introduction().isBlank()) {
             this.introduction = command.introduction();
         }
         return this;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -126,8 +126,12 @@ public class MemberEntity {
     }
 
     public MemberEntity update(UpdateMemberCommand command) {
-        this.nickname = command.nickname();
-        this.introduction = command.introduction();
+        if (!command.nickname().isBlank()) {
+            this.nickname = command.nickname();
+        }
+        if (!command.introduction().isBlank()) {
+            this.introduction = command.introduction();
+        }
         return this;
     }
 

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -103,6 +103,9 @@ public class ImageFacade {
     }
 
     private static boolean isDefaultProfileNumber(String imageName) {
-        return imageName.equals("1") || imageName.equals("2") || imageName.equals("3") || imageName.equals("4");
+        return imageName.equals("1")
+                || imageName.equals("2")
+                || imageName.equals("3")
+                || imageName.equals("4");
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -83,9 +83,11 @@ public class ImageFacade {
 
     public void changeProfileImageUrl(Long memberId, String imageName) {
         // 존재하는 이미지를 지운다
-        Member member = memberService.findById(memberId);
-        if (member.getProfileImageUrl() != null && !member.getProfileImageUrl().isEmpty()) {
-            imageDeleteUseCase.deleteProfileImage(member.getProfileImageUrl());
+        if (!isDefaultProfileNumber(imageName)) {
+            Member member = memberService.findById(memberId);
+            if (member.getProfileImageUrl() != null && !member.getProfileImageUrl().isEmpty()) {
+                imageDeleteUseCase.deleteProfileImage(member.getProfileImageUrl());
+            }
         }
         // 멤버의 프로필 이미지 URL 정보를 수정한다
         memberService.updateProfileImageUrl(memberId, imageName);
@@ -98,5 +100,9 @@ public class ImageFacade {
 
     public void deleteAllImagesByMemoryId(Long memoryId) {
         imageDeleteUseCase.deleteAllImagesByMemoryId(memoryId);
+    }
+
+    private static boolean isDefaultProfileNumber(String imageName) {
+        return imageName.equals("1") || imageName.equals("2") || imageName.equals("3") || imageName.equals("4");
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -102,10 +102,9 @@ public class ImageFacade {
         imageDeleteUseCase.deleteAllImagesByMemoryId(memoryId);
     }
 
+    private static final List<String> DEFAULT_IMAGE_NAMES = List.of("1", "2", "3", "4");
+
     private static boolean isDefaultProfileNumber(String imageName) {
-        return imageName.equals("1")
-                || imageName.equals("2")
-                || imageName.equals("3")
-                || imageName.equals("4");
+        return DEFAULT_IMAGE_NAMES.contains(imageName);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #268

## 📌 작업 내용 및 특이사항
- 닉네임만 수정 -> 자기소개도 초기화되는 오류를 해결합니다.
- 기본 프로필 이미지 정보를 저장할 수 있도록 구현부를 추가합니다.

## 📝 참고사항
- 닉네임, 한 줄 소개 함께 수정 성공
<img width="854" alt="Screenshot 2024-08-27 at 13 02 04" src="https://github.com/user-attachments/assets/d8983534-37da-4d4d-88f0-15241c93be75">
<img width="843" alt="Screenshot 2024-08-27 at 13 02 37" src="https://github.com/user-attachments/assets/4d59cca5-a87f-4164-9613-7d42a22ec71d">

- 닉네임만 수정 성공
<img width="845" alt="Screenshot 2024-08-27 at 13 04 38" src="https://github.com/user-attachments/assets/462db72f-b9a0-42a3-9ebc-20aa5e95cfb7">
<img width="841" alt="Screenshot 2024-08-27 at 13 04 43" src="https://github.com/user-attachments/assets/0aaaf653-dcd3-49a2-9e66-da801576edce">

- 한 줄 소개만 수정 성공
<img width="848" alt="Screenshot 2024-08-27 at 13 10 41" src="https://github.com/user-attachments/assets/53c856fe-f4fd-4e15-ab76-d37eff621874">
<img width="844" alt="Screenshot 2024-08-27 at 13 10 49" src="https://github.com/user-attachments/assets/ee295215-8ac6-4311-ad78-53c9f1493d63">

- 한 줄 소개만 수정 시에도 닉네임 필드는 필수 (Blank check가 필요함)
<img width="844" alt="Screenshot 2024-08-27 at 13 09 33" src="https://github.com/user-attachments/assets/8d4c60ce-5bb1-4303-9965-4f43eca6d35a">