### PR TITLE
fix: jenkins 명령어 수정 및 deploy.sh docker run 에 바인드 명령어 추가

### DIFF
--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -26,8 +26,6 @@ pipeline {
 
         stage('빌드') {
             steps {
-                withCredentials([file(credentialsId: 'GOOGLE_CREDENTIAL_JSON', variable: 'spreadsheetJson')])
-                sh 'cp $spreadsheetJson ./module-infrastructure/google-spreadsheet/src/main/resources/'
                 sh 'chmod u+w ./module-presentation/src/main/resources/'
                 sh 'chmod +x ./gradlew'
                 sh './gradlew :module-presentation:build'

--- a/scripts/shell/deploy.sh
+++ b/scripts/shell/deploy.sh
@@ -40,7 +40,7 @@ docker pull ${user_id}/${server_name}
 # green_port로 서버 실행
 echo "> ${green_port} 포트로 서버 실행"
 echo "> docker run -d --name ${server_name}-${green_port} --network swimie-network --env-file application-secret.properties -p ${green_port}:8080 -e TZ=Asia/Seoul ${user_id}/${server_name}"
-docker run -d --name ${server_name}-${green_port} --network swimie-network --env-file application-secret.properties -p ${green_port}:8080 -e TZ=Asia/Seoul ${user_id}/${server_name}
+docker run -d --name ${server_name}-${green_port} --network swimie-network --env-file application-secret.properties -p ${green_port}:8080 -e TZ=Asia/Seoul  -v /root/spreadsheet:/app/spreadsheet ${user_id}/${server_name}
 echo "----------------------------------------------------------------------"
 
 # green_port 서버 제대로 실행 중인지 확인

--- a/scripts/shell/deploy.sh
+++ b/scripts/shell/deploy.sh
@@ -39,8 +39,8 @@ docker pull ${user_id}/${server_name}
 
 # green_port로 서버 실행
 echo "> ${green_port} 포트로 서버 실행"
-echo "> docker run -d --name ${server_name}-${green_port} --network swimie-network --env-file application-secret.properties -p ${green_port}:8080 -e TZ=Asia/Seoul ${user_id}/${server_name}"
-docker run -d --name ${server_name}-${green_port} --network swimie-network --env-file application-secret.properties -p ${green_port}:8080 -e TZ=Asia/Seoul  -v /root/spreadsheet:/app/spreadsheet ${user_id}/${server_name}
+echo "> docker run -d --name ${server_name}-${green_port} --network swimie-network --env-file application-secret.properties -p ${green_port}:8080 -e TZ=Asia/Seoul -v /root/spreadsheet:/app/spreadsheet ${user_id}/${server_name}"
+docker run -d --name ${server_name}-${green_port} --network swimie-network --env-file application-secret.properties -p ${green_port}:8080 -e TZ=Asia/Seoul -v /root/spreadsheet:/app/spreadsheet ${user_id}/${server_name}
 echo "----------------------------------------------------------------------"
 
 # green_port 서버 제대로 실행 중인지 확인


### PR DESCRIPTION
## 🌱 관련 이슈

- close #272 

## 📌 작업 내용 및 특이사항
- jenkinsfile의 명령어 롤백 및 deploy.sh 파일에 docker run 명령어에 바인드 명령어를 추가하였습니다. 
- json 파일은 메인 서버 /spreadsheet 폴더에 옳겨놓은 상태이고 application-secret.properties에 파일 위치 설정해두었습니다