### PR TITLE
fix: 입력 값 검증 방식 변경

### DIFF
--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -83,6 +83,9 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUp
 
     @Override
     public Member update(UpdateMemberCommand command) {
+        if (command.nickname() != null && command.nickname().isBlank()) {
+            throw new BadRequestException(MemberErrorType.NAME_CANNOT_BE_BLANK);
+        }
         return memberPersistencePort
                 .update(command)
                 .orElseThrow(() -> new InternalServerException(MemberErrorType.UPDATE_FAILED));

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -129,7 +129,7 @@ public class MemberEntity {
         if (command.nickname() != null && !command.nickname().isBlank()) {
             this.nickname = command.nickname();
         }
-        if (command.introduction() != null && !command.introduction().isBlank()) {
+        if (command.introduction() != null) {
             this.introduction = command.introduction();
         }
         return this;

--- a/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/request/MemberUpdateRequest.java
@@ -1,11 +1,9 @@
 package com.depromeet.member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 
 public record MemberUpdateRequest(
-        @NotBlank(message = "멤버의 이름은 비어 있을 수 없습니다")
-                @Schema(description = "닉네임", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(description = "닉네임", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
                 String nickname,
         @Schema(description = "한 줄 소개", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
                 String introduction) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #282

## 📌 작업 내용 및 특이사항
- 클라이언트 요청에 따라 입력 값 검증 방식을 수정하였습니다.
- nickname 필드가 null이어도 introduction이 수정될 수 있도록 구현하였습니다.

## 📝 참고사항
- 모든 경우의 수
<img width="845" alt="Screenshot 2024-08-27 at 21 22 35" src="https://github.com/user-attachments/assets/4d111af9-4fdc-4e74-966d-98c09c4265bb">
<img width="833" alt="Screenshot 2024-08-27 at 21 22 50" src="https://github.com/user-attachments/assets/fa53f2fd-ccda-44e8-8cc8-36ae1e42d41f">
<img width="834" alt="Screenshot 2024-08-27 at 21 23 03" src="https://github.com/user-attachments/assets/71e86ccc-50ae-477c-9e99-772037937b4d">
<img width="839" alt="Screenshot 2024-08-27 at 21 23 09" src="https://github.com/user-attachments/assets/a7ccf555-9cf4-4329-b8ef-e0f350eea4a3">
<img width="842" alt="Screenshot 2024-08-27 at 21 23 18" src="https://github.com/user-attachments/assets/9cb9f8f6-cc1d-477a-8199-38d071e9a35f">
<img width="845" alt="Screenshot 2024-08-27 at 21 23 32" src="https://github.com/user-attachments/assets/c6f7bc68-169f-401c-9e72-8371826ff2bd">
<img width="843" alt="Screenshot 2024-08-27 at 21 23 39" src="https://github.com/user-attachments/assets/16842ab3-e6c1-4c63-ac3a-20fe611a0318">