### PR TITLE
refactor: 알림 조회 API 스펙 변경 및 로그 수집 방식 변경

### DIFF
--- a/module-domain/src/main/java/com/depromeet/notification/port/out/FollowLogPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/out/FollowLogPersistencePort.java
@@ -15,4 +15,6 @@ public interface FollowLogPersistencePort {
     Long countUnread(Long memberId);
 
     void deleteAllByMemberId(Long memberId);
+
+    boolean existsByReceiverIdAndFollowerId(Long receiverId, Long followerId);
 }

--- a/module-domain/src/main/java/com/depromeet/notification/service/FollowLogService.java
+++ b/module-domain/src/main/java/com/depromeet/notification/service/FollowLogService.java
@@ -31,6 +31,11 @@ public class FollowLogService
     public void save(FollowLogEvent event) {
         Long receiverId = event.receiver().getId();
         Long followerId = event.follower().getId();
+
+        if (followLogPersistencePort.existsByReceiverIdAndFollowerId(receiverId, followerId)) {
+            return;
+        }
+
         String typeString =
                 friendPersistencePort
                         .findByMemberIdAndFollowingId(receiverId, followerId)

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/FollowLogRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/FollowLogRepository.java
@@ -75,6 +75,15 @@ public class FollowLogRepository implements FollowLogPersistencePort {
                 .execute();
     }
 
+    @Override
+    public boolean existsByReceiverIdAndFollowerId(Long receiverId, Long followerId) {
+        return queryFactory
+                        .selectFrom(followLogEntity)
+                        .where(memberEq(receiverId), followerEq(followerId))
+                        .fetchFirst()
+                != null;
+    }
+
     private static BooleanExpression followerEq(Long memberId) {
         if (memberId == null) {
             return null;

--- a/module-presentation/src/main/java/com/depromeet/notification/dto/response/FriendNotificationResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/dto/response/FriendNotificationResponse.java
@@ -9,16 +9,19 @@ import lombok.Getter;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class FriendNotificationResponse extends BaseNotificationResponse {
+    private final Long memberId;
     private final String profileImageUrl;
 
     public FriendNotificationResponse(
-            Long id,
+            Long notificationId,
             String nickname,
             LocalDateTime createdAt,
             String type,
             boolean hasRead,
+            Long memberId,
             String profileImageUrl) {
-        super(id, nickname, createdAt, type, hasRead);
+        super(notificationId, nickname, createdAt, type, hasRead);
+        this.memberId = memberId;
         this.profileImageUrl = profileImageUrl;
     }
 
@@ -29,6 +32,7 @@ public class FriendNotificationResponse extends BaseNotificationResponse {
                 followLog.getCreatedAt(),
                 "FRIEND",
                 followLog.isHasRead(),
+                followLog.getFollower().getId(),
                 getImageUrl(profileImageOrigin, followLog.getFollower()));
     }
 

--- a/module-presentation/src/main/java/com/depromeet/notification/dto/response/ReactionNotificationResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/dto/response/ReactionNotificationResponse.java
@@ -12,8 +12,9 @@ import lombok.Getter;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReactionNotificationResponse extends BaseNotificationResponse {
-    private final LocalDate recordCreatedAt;
+    private final Long memoryId;
     private final String content;
+    private final LocalDate recordCreatedAt;
 
     @Builder
     public ReactionNotificationResponse(
@@ -22,11 +23,13 @@ public class ReactionNotificationResponse extends BaseNotificationResponse {
             LocalDateTime createdAt,
             String type,
             boolean hasRead,
-            LocalDate recordCreatedAt,
-            String content) {
+            Long memoryId,
+            String content,
+            LocalDate recordCreatedAt) {
         super(notificationId, nickname, createdAt, type, hasRead);
-        this.recordCreatedAt = recordCreatedAt;
+        this.memoryId = memoryId;
         this.content = content;
+        this.recordCreatedAt = recordCreatedAt;
     }
 
     public static List<BaseNotificationResponse> from(List<ReactionLog> reactionLogs) {
@@ -39,10 +42,11 @@ public class ReactionNotificationResponse extends BaseNotificationResponse {
                                         it.getCreatedAt(),
                                         "CHEER",
                                         it.isHasRead(),
-                                        it.getReaction().getMemory().getRecordAt(),
+                                        it.getReaction().getMemory().getId(),
                                         it.getReaction().getEmoji()
                                                 + " "
-                                                + it.getReaction().getComment()))
+                                                + it.getReaction().getComment(),
+                                        it.getReaction().getMemory().getRecordAt()))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #285 

## 📌 작업 내용 및 특이사항
- 알림 조회 시 FRIEND는 memberId 필드 추가, CHEER(REACTION)은 memoryId 필드를 추가하였습니다.
- 한 사람이 팔로우를 했다가 취소 후 다시 팔로우할 시 여러번 로그가 쌓이는 것을 방지하였습니다.