### PR TITLE
fix: 알림 조회 시 응원 content null로 나오는 문제 해결

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/notification/dto/response/ReactionNotificationResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/dto/response/ReactionNotificationResponse.java
@@ -43,10 +43,14 @@ public class ReactionNotificationResponse extends BaseNotificationResponse {
                                         "CHEER",
                                         it.isHasRead(),
                                         it.getReaction().getMemory().getId(),
-                                        it.getReaction().getEmoji()
-                                                + " "
-                                                + it.getReaction().getComment(),
+                                        it.getReaction().getEmoji() + getComment(it),
                                         it.getReaction().getMemory().getRecordAt()))
                 .collect(Collectors.toList());
+    }
+
+    private static String getComment(ReactionLog reactionLog) {
+        return reactionLog.getReaction().getComment() != null
+                ? " " + reactionLog.getReaction().getComment()
+                : "";
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #289 

## 📌 작업 내용 및 특이사항
- 알림 조회 시 응원 content null로 나오는 문제 해결

## 📝 참고사항
`[변경 전]`
<img width="291" alt="스크린샷 2024-08-27 오후 11 56 45" src="https://github.com/user-attachments/assets/9e02adf2-f0da-43c2-b046-691d4173bab3">

`[변경 후]`
<img width="283" alt="image" src="https://github.com/user-attachments/assets/7b953190-9120-4dd4-b8b8-7e0f9c780194">
