### PR TITLE
feat: 여러 회원에 대한 팔로우 여부 확인 기능 추가

### DIFF
--- a/module-domain/src/main/java/com/depromeet/friend/domain/vo/FollowCheck.java
+++ b/module-domain/src/main/java/com/depromeet/friend/domain/vo/FollowCheck.java
@@ -1,0 +1,4 @@
+package com.depromeet.friend.domain.vo;
+
+public record FollowCheck(Long targetId, Boolean isFollowing) {
+}

--- a/module-domain/src/main/java/com/depromeet/friend/domain/vo/FollowCheck.java
+++ b/module-domain/src/main/java/com/depromeet/friend/domain/vo/FollowCheck.java
@@ -1,4 +1,3 @@
 package com.depromeet.friend.domain.vo;
 
-public record FollowCheck(Long targetId, Boolean isFollowing) {
-}
+public record FollowCheck(Long targetId, Boolean isFollowing) {}

--- a/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
@@ -24,5 +24,5 @@ public interface FollowUseCase {
 
     void deleteByMemberId(Long memberId);
 
-    Boolean isFollowing(Long memberId, Long targetMemberId);
+    List<Boolean> isFollowing(Long memberId, List<Long> targetMemberId);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
@@ -1,9 +1,6 @@
 package com.depromeet.friend.port.in;
 
-import com.depromeet.friend.domain.vo.FollowSlice;
-import com.depromeet.friend.domain.vo.Follower;
-import com.depromeet.friend.domain.vo.Following;
-import com.depromeet.friend.domain.vo.FriendCount;
+import com.depromeet.friend.domain.vo.*;
 import com.depromeet.member.domain.Member;
 import java.util.List;
 
@@ -24,5 +21,5 @@ public interface FollowUseCase {
 
     void deleteByMemberId(Long memberId);
 
-    List<Boolean> isFollowing(Long memberId, List<Long> targetMemberId);
+    List<FollowCheck> isFollowing(Long memberId, List<Long> targetMemberId);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
@@ -1,10 +1,7 @@
 package com.depromeet.friend.port.out.persistence;
 
 import com.depromeet.friend.domain.Friend;
-import com.depromeet.friend.domain.vo.FollowSlice;
-import com.depromeet.friend.domain.vo.Follower;
-import com.depromeet.friend.domain.vo.Following;
-import com.depromeet.friend.domain.vo.FriendCount;
+import com.depromeet.friend.domain.vo.*;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,4 +27,6 @@ public interface FriendPersistencePort {
     FriendCount countFriendByMemberId(Long memberId);
 
     void deleteByMemberId(Long memberId);
+
+    List<FollowCheck> findByMemberIdAndFollowingIds(Long memberId, List<Long> targetMemberId);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -2,10 +2,7 @@ package com.depromeet.friend.service;
 
 import com.depromeet.exception.BadRequestException;
 import com.depromeet.friend.domain.Friend;
-import com.depromeet.friend.domain.vo.FollowSlice;
-import com.depromeet.friend.domain.vo.Follower;
-import com.depromeet.friend.domain.vo.Following;
-import com.depromeet.friend.domain.vo.FriendCount;
+import com.depromeet.friend.domain.vo.*;
 import com.depromeet.friend.port.in.FollowUseCase;
 import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
 import com.depromeet.member.domain.Member;
@@ -77,17 +74,17 @@ public class FollowService implements FollowUseCase {
     }
 
     @Override
-    public List<Boolean> isFollowing(Long memberId, List<Long> targetMemberId) {
-        List<Boolean> result = new ArrayList<>();
+    public List<FollowCheck> isFollowing(Long memberId, List<Long> targetMemberId) {
+        List<FollowCheck> result = new ArrayList<>();
         targetMemberId.forEach(
-                target -> {
-                    if (memberId.equals(target)) {
+                targetId -> {
+                    if (memberId.equals(targetId)) {
                         throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
                     }
-                    result.add(
+                    result.add(new FollowCheck(targetId,
                             friendPersistencePort
-                                    .findByMemberIdAndFollowingId(memberId, target)
-                                    .isPresent());
+                                    .findByMemberIdAndFollowingId(memberId, targetId)
+                                    .isPresent()));
                 });
         return result;
     }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -10,7 +10,6 @@ import com.depromeet.friend.port.in.FollowUseCase;
 import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
 import com.depromeet.member.domain.Member;
 import com.depromeet.type.friend.FollowErrorType;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -80,14 +79,16 @@ public class FollowService implements FollowUseCase {
     @Override
     public List<Boolean> isFollowing(Long memberId, List<Long> targetMemberId) {
         List<Boolean> result = new ArrayList<>();
-        targetMemberId.forEach(target -> {
-            if (memberId.equals(target)) {
-                throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
-            }
-            result.add(friendPersistencePort
-                    .findByMemberIdAndFollowingId(memberId, target)
-                    .isPresent());
-        });
+        targetMemberId.forEach(
+                target -> {
+                    if (memberId.equals(target)) {
+                        throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
+                    }
+                    result.add(
+                            friendPersistencePort
+                                    .findByMemberIdAndFollowingId(memberId, target)
+                                    .isPresent());
+                });
         return result;
     }
 }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -81,10 +81,12 @@ public class FollowService implements FollowUseCase {
                     if (memberId.equals(targetId)) {
                         throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
                     }
-                    result.add(new FollowCheck(targetId,
-                            friendPersistencePort
-                                    .findByMemberIdAndFollowingId(memberId, targetId)
-                                    .isPresent()));
+                    result.add(
+                            new FollowCheck(
+                                    targetId,
+                                    friendPersistencePort
+                                            .findByMemberIdAndFollowingId(memberId, targetId)
+                                            .isPresent()));
                 });
         return result;
     }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -10,6 +10,8 @@ import com.depromeet.friend.port.in.FollowUseCase;
 import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
 import com.depromeet.member.domain.Member;
 import com.depromeet.type.friend.FollowErrorType;
+
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -76,12 +78,16 @@ public class FollowService implements FollowUseCase {
     }
 
     @Override
-    public Boolean isFollowing(Long memberId, Long targetMemberId) {
-        if (memberId.equals(targetMemberId)) {
-            throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
-        }
-        return friendPersistencePort
-                .findByMemberIdAndFollowingId(memberId, targetMemberId)
-                .isPresent();
+    public List<Boolean> isFollowing(Long memberId, List<Long> targetMemberId) {
+        List<Boolean> result = new ArrayList<>();
+        targetMemberId.forEach(target -> {
+            if (memberId.equals(target)) {
+                throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
+            }
+            result.add(friendPersistencePort
+                    .findByMemberIdAndFollowingId(memberId, target)
+                    .isPresent());
+        });
+        return result;
     }
 }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -7,7 +7,6 @@ import com.depromeet.friend.port.in.FollowUseCase;
 import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
 import com.depromeet.member.domain.Member;
 import com.depromeet.type.friend.FollowErrorType;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -75,19 +74,9 @@ public class FollowService implements FollowUseCase {
 
     @Override
     public List<FollowCheck> isFollowing(Long memberId, List<Long> targetMemberId) {
-        List<FollowCheck> result = new ArrayList<>();
-        targetMemberId.forEach(
-                targetId -> {
-                    if (memberId.equals(targetId)) {
-                        throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
-                    }
-                    result.add(
-                            new FollowCheck(
-                                    targetId,
-                                    friendPersistencePort
-                                            .findByMemberIdAndFollowingId(memberId, targetId)
-                                            .isPresent()));
-                });
-        return result;
+        if (targetMemberId != null && targetMemberId.contains(memberId)) {
+            throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
+        }
+        return friendPersistencePort.findByMemberIdAndFollowingIds(memberId, targetMemberId);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
@@ -3,6 +3,7 @@ package com.depromeet.member.port.in.usecase;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
+import java.util.List;
 
 public interface MemberUseCase {
     Member findById(Long id);
@@ -16,4 +17,6 @@ public interface MemberUseCase {
     Member findByProviderId(String providerId);
 
     Member createMemberBy(SocialMemberCommand command);
+
+    void checkByIdExist(List<Long> friends);
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
@@ -4,6 +4,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberPersistencePort {
@@ -30,4 +31,6 @@ public interface MemberPersistencePort {
     Optional<Member> update(UpdateMemberCommand command);
 
     Optional<Member> updateProfileImageUrl(Long memberId, String profileImageUrl);
+
+    Boolean checkByIdExist(List<Long> friends);
 }

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -15,6 +15,7 @@ import com.depromeet.member.port.in.usecase.MemberUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import com.depromeet.type.member.MemberErrorType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -79,6 +80,13 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUp
                         .providerId(command.providerId())
                         .build();
         return memberPersistencePort.save(member);
+    }
+
+    @Override
+    public void checkByIdExist(List<Long> friends) {
+        if (!memberPersistencePort.checkByIdExist(friends)) {
+            throw new BadRequestException(MemberErrorType.NOT_FOUND_FROM_ID_LIST);
+        }
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemberRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemberRepository.java
@@ -122,4 +122,15 @@ public class FakeMemberRepository implements MemberPersistencePort {
                             return member;
                         });
     }
+
+    @Override
+    public Boolean checkByIdExist(List<Long> friends) {
+        List<Long> idList = data.stream().map(Member::getId).toList();
+        for (Long id : friends) {
+            if (!idList.contains(id)) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
@@ -11,7 +11,8 @@ public enum MemberErrorType implements ErrorType {
     GENDER_CANNOT_BE_BLANK("MEMBER_6", "멤버의 성별은 공백이 허용되지 않습니다"),
     UPDATE_FAILED("MEMBER_7", "멤버의 정보 수정에 실패하였습니다"),
     UPDATE_PROFILE_IMAGE_FAILED("MEMBER_8", "멤버의 프로필 이미지 수정에 실패하였습니다"),
-    UPDATE_LAST_VIEWED_FOLLOWING_LOG_AT("MEMBER_9", "멤버의 최근 팔로잉 소식 조회 시간 변경에 실패하였습니다");
+    UPDATE_LAST_VIEWED_FOLLOWING_LOG_AT("MEMBER_9", "멤버의 최근 팔로잉 소식 조회 시간 변경에 실패하였습니다"),
+    NOT_FOUND_FROM_ID_LIST("MEMBER_10", "요청된 멤버 ID 중 존재하지 않는 멤버가 있습니다");
 
     private final String code;
     private final String message;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
@@ -4,10 +4,7 @@ import static com.depromeet.friend.entity.QFriendEntity.friendEntity;
 import static com.querydsl.jpa.JPAExpressions.select;
 
 import com.depromeet.friend.domain.Friend;
-import com.depromeet.friend.domain.vo.FollowSlice;
-import com.depromeet.friend.domain.vo.Follower;
-import com.depromeet.friend.domain.vo.Following;
-import com.depromeet.friend.domain.vo.FriendCount;
+import com.depromeet.friend.domain.vo.*;
 import com.depromeet.friend.entity.FriendEntity;
 import com.depromeet.friend.entity.QFriendEntity;
 import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
@@ -17,6 +14,7 @@ import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,6 +32,7 @@ public class FriendRepository implements FriendPersistencePort {
     private final FriendJpaRepository friendJpaRepository;
 
     private QFriendEntity friend = QFriendEntity.friendEntity;
+    private QMemberEntity member = QMemberEntity.memberEntity;
 
     @Override
     public Friend addFollow(Friend friend) {
@@ -222,5 +221,24 @@ public class FriendRepository implements FriendPersistencePort {
                 .delete(friend)
                 .where(friend.member.id.eq(memberId).or(friend.following.id.eq(memberId)))
                 .execute();
+    }
+
+    @Override
+    public List<FollowCheck> findByMemberIdAndFollowingIds(
+            Long memberId, List<Long> targetMemberId) {
+        JPAQuery<Tuple> result =
+                queryFactory
+                        .select(
+                                member.id,
+                                member.id.in(
+                                        queryFactory
+                                                .select(friend.following.id)
+                                                .from(friend)
+                                                .where(friend.member.id.eq(memberId))))
+                        .from(member)
+                        .where(member.id.in(targetMemberId));
+        return result.stream()
+                .map(res -> new FollowCheck(res.get(0, Long.class), res.get(1, Boolean.class)))
+                .toList();
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
@@ -1,5 +1,7 @@
 package com.depromeet.member.repository;
 
+import static com.querydsl.core.types.ExpressionUtils.count;
+
 import com.depromeet.friend.entity.QFriendEntity;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
@@ -148,6 +150,17 @@ public class MemberRepository implements MemberPersistencePort {
         return memberJpaRepository
                 .findById(memberId)
                 .map(memberEntity -> memberEntity.updateProfileImageUrl(profileImageUrl).toModel());
+    }
+
+    @Override
+    public Boolean checkByIdExist(List<Long> friends) {
+        Long resultSize =
+                queryFactory
+                        .select(count(member.id))
+                        .from(member)
+                        .where(member.id.in(friends))
+                        .fetchOne();
+        return resultSize != null && resultSize.intValue() == friends.size();
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
@@ -1,6 +1,7 @@
 package com.depromeet.friend.api;
 
 import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.friend.dto.request.FollowCheckListRequest;
 import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.friend.dto.response.*;
 import com.depromeet.member.annotation.LoginMember;
@@ -34,5 +35,5 @@ public interface FollowApi {
 
     @Operation(summary = "팔로잉 여부 조회")
     ApiResponse<IsFollowingResponse> checkFollowing(
-            @LoginMember Long memberId, @PathVariable("memberId") Long targetMemberId);
+            @LoginMember Long memberId, @RequestBody FollowCheckListRequest targetMemberId);
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
@@ -59,8 +59,7 @@ public class FollowController implements FollowApi {
     @PostMapping
     @Logging(item = "Follower/Following", action = "GET")
     public ApiResponse<IsFollowingResponse> checkFollowing(
-            @LoginMember Long memberId,
-            @RequestBody FollowCheckListRequest targetMemberId) {
+            @LoginMember Long memberId, @RequestBody FollowCheckListRequest targetMemberId) {
         IsFollowingResponse response = followFacade.isFollowing(memberId, targetMemberId);
         return ApiResponse.success(FollowSuccessType.CHECK_FOLLOWING_SUCCESS, response);
     }

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
@@ -2,6 +2,7 @@ package com.depromeet.friend.api;
 
 import com.depromeet.config.Logging;
 import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.friend.dto.request.FollowCheckListRequest;
 import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.friend.dto.response.*;
 import com.depromeet.friend.facade.FollowFacade;
@@ -55,10 +56,11 @@ public class FollowController implements FollowApi {
         return ApiResponse.success(FollowSuccessType.GET_FOLLOWING_SUMMARY_SUCCESS, response);
     }
 
-    @GetMapping("/{memberId}")
+    @PostMapping
     @Logging(item = "Follower/Following", action = "GET")
     public ApiResponse<IsFollowingResponse> checkFollowing(
-            @LoginMember Long memberId, @PathVariable("memberId") Long targetMemberId) {
+            @LoginMember Long memberId,
+            @RequestBody FollowCheckListRequest targetMemberId) {
         IsFollowingResponse response = followFacade.isFollowing(memberId, targetMemberId);
         return ApiResponse.success(FollowSuccessType.CHECK_FOLLOWING_SUCCESS, response);
     }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckListRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckListRequest.java
@@ -1,0 +1,10 @@
+package com.depromeet.friend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record FollowCheckListRequest(
+        @Schema(description = "팔로우 여부를 확인하고 싶은 member PK 배열", example = "[1, 2, 3]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        List<Long> friends) {
+}

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckListRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckListRequest.java
@@ -1,10 +1,11 @@
 package com.depromeet.friend.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.List;
 
 public record FollowCheckListRequest(
-        @Schema(description = "팔로우 여부를 확인하고 싶은 member PK 배열", example = "[1, 2, 3]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-        List<Long> friends) {
-}
+        @Schema(
+                        description = "팔로우 여부를 확인하고 싶은 member PK 배열",
+                        example = "[1, 2, 3]",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                List<Long> friends) {}

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckResponse.java
@@ -1,0 +1,16 @@
+package com.depromeet.friend.dto.request;
+
+import com.depromeet.friend.domain.vo.FollowCheck;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record FollowCheckResponse(
+        @Schema(description = "팔로우 여부 조회 대상 member id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+        Long memberId,
+        @Schema(description = "팔로우 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        Boolean isFollowing) {
+        public static FollowCheckResponse of(FollowCheck isFollowing) {
+                return new FollowCheckResponse(isFollowing.targetId(), isFollowing.isFollowing());
+        }
+}

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/request/FollowCheckResponse.java
@@ -3,14 +3,18 @@ package com.depromeet.friend.dto.request;
 import com.depromeet.friend.domain.vo.FollowCheck;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.List;
-
 public record FollowCheckResponse(
-        @Schema(description = "팔로우 여부 조회 대상 member id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-        Long memberId,
-        @Schema(description = "팔로우 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-        Boolean isFollowing) {
-        public static FollowCheckResponse of(FollowCheck isFollowing) {
-                return new FollowCheckResponse(isFollowing.targetId(), isFollowing.isFollowing());
-        }
+        @Schema(
+                        description = "팔로우 여부 조회 대상 member id",
+                        example = "1",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                Long memberId,
+        @Schema(
+                        description = "팔로우 여부",
+                        example = "true",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                Boolean isFollowing) {
+    public static FollowCheckResponse of(FollowCheck isFollowing) {
+        return new FollowCheckResponse(isFollowing.targetId(), isFollowing.isFollowing());
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
@@ -3,14 +3,16 @@ package com.depromeet.friend.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
+import java.util.List;
+
 public record IsFollowingResponse(
         @NotNull
                 @Schema(
                         description = "팔로잉 여부",
-                        example = "true",
+                        example = "[true, false, true]",
                         requiredMode = Schema.RequiredMode.REQUIRED)
-                Boolean isFollowing) {
-    public static IsFollowingResponse toIsFollowingResponse(Boolean isFollowing) {
+        List<Boolean> isFollowing) {
+    public static IsFollowingResponse toIsFollowingResponse(List<Boolean> isFollowing) {
         return new IsFollowingResponse(isFollowing);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
@@ -2,7 +2,6 @@ package com.depromeet.friend.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-
 import java.util.List;
 
 public record IsFollowingResponse(
@@ -11,7 +10,7 @@ public record IsFollowingResponse(
                         description = "팔로잉 여부",
                         example = "[true, false, true]",
                         requiredMode = Schema.RequiredMode.REQUIRED)
-        List<Boolean> isFollowing) {
+                List<Boolean> isFollowing) {
     public static IsFollowingResponse toIsFollowingResponse(List<Boolean> isFollowing) {
         return new IsFollowingResponse(isFollowing);
     }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/IsFollowingResponse.java
@@ -1,5 +1,7 @@
 package com.depromeet.friend.dto.response;
 
+import com.depromeet.friend.domain.vo.FollowCheck;
+import com.depromeet.friend.dto.request.FollowCheckResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -10,8 +12,8 @@ public record IsFollowingResponse(
                         description = "팔로잉 여부",
                         example = "[true, false, true]",
                         requiredMode = Schema.RequiredMode.REQUIRED)
-                List<Boolean> isFollowing) {
-    public static IsFollowingResponse toIsFollowingResponse(List<Boolean> isFollowing) {
-        return new IsFollowingResponse(isFollowing);
+                List<FollowCheckResponse> isFollowing) {
+    public static IsFollowingResponse toIsFollowingResponse(List<FollowCheck> isFollowing) {
+        return new IsFollowingResponse(isFollowing.stream().map(FollowCheckResponse::of).toList());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -1,5 +1,6 @@
 package com.depromeet.friend.facade;
 
+import com.depromeet.friend.domain.vo.FollowCheck;
 import com.depromeet.friend.domain.vo.FollowSlice;
 import com.depromeet.friend.domain.vo.Follower;
 import com.depromeet.friend.domain.vo.Following;
@@ -58,7 +59,7 @@ public class FollowFacade {
     }
 
     public IsFollowingResponse isFollowing(Long memberId, FollowCheckListRequest targetMemberId) {
-        List<Boolean> isFollowing = followUseCase.isFollowing(memberId, targetMemberId.friends());
+        List<FollowCheck> isFollowing = followUseCase.isFollowing(memberId, targetMemberId.friends());
         return IsFollowingResponse.toIsFollowingResponse(isFollowing);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -58,7 +58,9 @@ public class FollowFacade {
                 followingCount, followings, profileImageOrigin);
     }
 
+    @Transactional
     public IsFollowingResponse isFollowing(Long memberId, FollowCheckListRequest targetMemberId) {
+        memberUseCase.checkByIdExist(targetMemberId.friends());
         List<FollowCheck> isFollowing =
                 followUseCase.isFollowing(memberId, targetMemberId.friends());
         return IsFollowingResponse.toIsFollowingResponse(isFollowing);

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -59,7 +59,8 @@ public class FollowFacade {
     }
 
     public IsFollowingResponse isFollowing(Long memberId, FollowCheckListRequest targetMemberId) {
-        List<FollowCheck> isFollowing = followUseCase.isFollowing(memberId, targetMemberId.friends());
+        List<FollowCheck> isFollowing =
+                followUseCase.isFollowing(memberId, targetMemberId.friends());
         return IsFollowingResponse.toIsFollowingResponse(isFollowing);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -3,6 +3,7 @@ package com.depromeet.friend.facade;
 import com.depromeet.friend.domain.vo.FollowSlice;
 import com.depromeet.friend.domain.vo.Follower;
 import com.depromeet.friend.domain.vo.Following;
+import com.depromeet.friend.dto.request.FollowCheckListRequest;
 import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.friend.dto.response.*;
 import com.depromeet.friend.port.in.FollowUseCase;
@@ -56,8 +57,8 @@ public class FollowFacade {
                 followingCount, followings, profileImageOrigin);
     }
 
-    public IsFollowingResponse isFollowing(Long memberId, Long targetMemberId) {
-        Boolean isFollowing = followUseCase.isFollowing(memberId, targetMemberId);
+    public IsFollowingResponse isFollowing(Long memberId, FollowCheckListRequest targetMemberId) {
+        List<Boolean> isFollowing = followUseCase.isFollowing(memberId, targetMemberId.friends());
         return IsFollowingResponse.toIsFollowingResponse(isFollowing);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #295

## 📌 작업 내용 및 특이사항
- 클라이언트 측 요청에 따라 여러 회원에 대한 팔로우 여부 확인 기능을 추가하여 기존 API를 수정하였습니다.

## 📝 참고사항
- 조회 성공
<img width="850" alt="Screenshot 2024-08-28 at 10 48 03" src="https://github.com/user-attachments/assets/0c9a4cbb-9e46-42ed-b226-a26be1457468">

- 조회 시 본인 id가 포함된 경우 오류
<img width="844" alt="Screenshot 2024-08-28 at 10 35 00" src="https://github.com/user-attachments/assets/e445da28-e074-4768-99ac-57816353304a">

- 단일 조회 성공
<img width="836" alt="Screenshot 2024-08-28 at 10 48 10" src="https://github.com/user-attachments/assets/6c9bfb35-8890-4a3a-8490-320c41464ce3">

- 존재하지 않는 id가 포함되어 조회 요청하는 경우 오류
<img width="859" alt="Screenshot 2024-08-28 at 13 32 17" src="https://github.com/user-attachments/assets/ab1f7cfa-637b-4337-a079-3a254e55f938">

- 쿼리 결과
<img width="305" alt="Screenshot 2024-08-28 at 13 39 15" src="https://github.com/user-attachments/assets/0a5867eb-e5ee-474b-867e-afda6252c941">