### PR TITLE
fix: stroke 가 저장되어 있지 않는 memory 대상으로 팔로잉 소식 조회 시 나타나는 NPE 오류 해결

### DIFF
--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
@@ -22,9 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -77,8 +74,6 @@ public class FriendRepository implements FriendPersistencePort {
     @Override
     public FollowSlice<Following> findFollowingsByMemberIdAndCursorId(
             Long memberId, Long cursorId) {
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
-
         List<Following> content =
                 queryFactory
                         .select(
@@ -91,13 +86,13 @@ public class FriendRepository implements FriendPersistencePort {
                                         friend.following.introduction.as("introduction")))
                         .from(friend)
                         .where(friend.member.id.eq(memberId), ltCursorId(cursorId))
-                        .limit(pageable.getPageSize() + 1)
+                        .limit(11)
                         .orderBy(friend.id.desc())
                         .fetch();
 
         boolean hasNext = false;
         Long nextCursorId = null;
-        if (content.size() > pageable.getPageSize()) {
+        if (content.size() > 10) {
             content = new ArrayList<>(content);
             content.removeLast();
             hasNext = true;
@@ -114,8 +109,6 @@ public class FriendRepository implements FriendPersistencePort {
     @Override
     public FollowSlice<Follower> findFollowersByMemberIdAndCursorId(Long memberId, Long cursorId) {
         QFriendEntity subFriend = new QFriendEntity("sub");
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
-
         List<Follower> result =
                 queryFactory
                         .select(
@@ -137,13 +130,13 @@ public class FriendRepository implements FriendPersistencePort {
                                                 "hasFollowedBack")))
                         .from(friend)
                         .where(friend.following.id.eq(memberId), ltCursorId(cursorId))
-                        .limit(pageable.getPageSize() + 1)
+                        .limit(11)
                         .orderBy(friend.id.desc())
                         .fetch();
 
         boolean hasNext = false;
         Long nextCursorId = null;
-        if (result.size() > pageable.getPageSize()) {
+        if (result.size() > 10) {
             result = new ArrayList<>(result);
             result.removeLast();
             hasNext = true;

--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
@@ -116,7 +116,7 @@ public record FollowingLogMemoryResponse(
                 .endTime(memory.parseEndTime())
                 .diary(memory.getDiary())
                 .totalDistance(totalDistance)
-                .isAchieved(isAchieved(totalDistance, memory.getMember().getGoal()))
+                .isAchieved(memory.isAchieved(totalDistance))
                 .kcal(getKcalFromMemoryDetail(memory))
                 .type(memory.classifyType())
                 .strokes(strokeToDto(memory.getStrokes(), memory.getLane()))
@@ -131,13 +131,6 @@ public record FollowingLogMemoryResponse(
             return profileImageOrigin + "/" + member.getProfileImageUrl();
         }
         return null;
-    }
-
-    private static boolean isAchieved(Integer totalDistance, int goal) {
-        if (totalDistance == null) {
-            return false;
-        }
-        return totalDistance >= goal;
     }
 
     private static Integer getKcalFromMemoryDetail(Memory memory) {

--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
@@ -115,7 +115,7 @@ public record FollowingLogMemoryResponse(
                 .startTime(memory.parseStartTime())
                 .endTime(memory.parseEndTime())
                 .diary(memory.getDiary())
-                .totalDistance(memory.calculateTotalDistance())
+                .totalDistance(totalDistance)
                 .isAchieved(isAchieved(totalDistance, memory.getMember().getGoal()))
                 .kcal(getKcalFromMemoryDetail(memory))
                 .type(memory.classifyType())
@@ -134,6 +134,9 @@ public record FollowingLogMemoryResponse(
     }
 
     private static boolean isAchieved(Integer totalDistance, int goal) {
+        if (totalDistance == null) {
+            return false;
+        }
         return totalDistance >= goal;
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #297 

## 📌 작업 내용 및 특이사항
- 팔로잉 소식 조회할 때 stroke 가 저장되어 있지 않는 memory가 조회 대상에 포함되어있을때 npe가 뜨는 문제 해결함

원인 : totalDistance 가 null 인경우 isAchieved 로직에서 npe 가 발생했음

null 처리가 되어 있는 memory.isAchieved(totalDistance) 메서드 재사용하여 해결

## 📝 참고사항
- 오류 재현
![240828npe](https://github.com/user-attachments/assets/6113082e-6c15-4587-8288-7a85fcbe38be)

- 수정 완료
![240828 npe 오류 수정](https://github.com/user-attachments/assets/f151e259-aca7-47e1-bdb4-3612b70245c4)

