### PR TITLE
fix: 숫자 입력값(meter, laps, kcal...) 0이하로 입력이 되는 이슈 해결

### DIFF
--- a/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/memory/MemoryErrorType.java
@@ -9,7 +9,8 @@ public enum MemoryErrorType implements ErrorType {
     FORBIDDEN("MEMORY_4", "메모리에 접근 권한이 없습니다"),
     ALREADY_CREATED("MEMORY_5", "해당 날짜에 이미 기록이 존재합니다"),
     NOT_FOUND_PREV("MEMORY_6", "이전 기록이 존재하지 않습니다"),
-    NOT_FOUND_NEXT("MEMORY_7", "다음 기록이 존재하지 않습니다");
+    NOT_FOUND_NEXT("MEMORY_7", "다음 기록이 존재하지 않습니다"),
+    TIME_NOT_VALID("MEMORY_8", "시작 시간은 종료 시간을 역전할 수 없습니다");
 
     private final String code;
     private final String message;

--- a/module-presentation/src/main/java/com/depromeet/member/api/GoalController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/GoalController.java
@@ -9,6 +9,7 @@ import com.depromeet.member.dto.response.MemberSimpleResponse;
 import com.depromeet.member.port.in.usecase.GoalUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
 import com.depromeet.type.member.MemberSuccessType;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +23,7 @@ public class GoalController implements GoalApi {
     @PatchMapping
     @Logging(item = "Goal", action = "PATCH")
     public ApiResponse<MemberSimpleResponse> update(
-            @LoginMember Long memberId, @RequestBody GoalUpdateRequest goalUpdateRequest) {
+            @LoginMember Long memberId, @Valid @RequestBody GoalUpdateRequest goalUpdateRequest) {
         Member member = goalUpdateUseCase.updateGoal(memberId, goalUpdateRequest.goal());
         return ApiResponse.success(
                 MemberSuccessType.UPDATE_GOAL_SUCCESS,

--- a/module-presentation/src/main/java/com/depromeet/member/dto/request/GoalUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/request/GoalUpdateRequest.java
@@ -1,3 +1,5 @@
 package com.depromeet.member.dto.request;
 
-public record GoalUpdateRequest(Integer goal) {}
+import jakarta.validation.constraints.Min;
+
+public record GoalUpdateRequest(@Min(0) Integer goal) {}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
@@ -1,7 +1,10 @@
 package com.depromeet.memory.dto.request;
 
+import com.depromeet.exception.BadRequestException;
+import com.depromeet.type.memory.MemoryErrorType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -21,15 +24,19 @@ public class MemoryCreateRequest {
     @Schema(description = "수영 장비", example = "오리발")
     private String item;
 
+    @Min(0)
     @Schema(description = "심박수", example = "129")
     private Short heartRate;
 
+    @Min(0)
     @Schema(description = "페이스 분", example = "5", maxLength = 3, type = "int")
     private int paceMinutes;
 
+    @Min(0)
     @Schema(description = "페이스 초", example = "30", maxLength = 2, type = "int")
     private int paceSeconds;
 
+    @Min(0)
     @Schema(description = "칼로리", example = "300")
     private Integer kcal;
 
@@ -48,6 +55,7 @@ public class MemoryCreateRequest {
     @Schema(description = "수영 종료 시간", example = "11:50", maxLength = 8, type = "string")
     private LocalTime endTime;
 
+    @Min(0)
     @Schema(description = "레인 길이", example = "25")
     private Short lane;
 
@@ -78,6 +86,7 @@ public class MemoryCreateRequest {
             String diary,
             List<StrokeCreateRequest> strokes,
             List<Long> imageIdList) {
+        validateTime();
         this.poolId = poolId;
         this.item = item;
         this.heartRate = heartRate;
@@ -91,5 +100,11 @@ public class MemoryCreateRequest {
         this.diary = diary;
         this.strokes = strokes;
         this.imageIdList = imageIdList;
+    }
+
+    private void validateTime() {
+        if (startTime.isAfter(endTime)) {
+            throw new BadRequestException(MemoryErrorType.TIME_NOT_VALID);
+        }
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
@@ -1,6 +1,10 @@
 package com.depromeet.memory.dto.request;
 
+import com.depromeet.exception.BadRequestException;
+import com.depromeet.type.memory.MemoryErrorType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -20,15 +24,19 @@ public class MemoryUpdateRequest {
     @Schema(description = "수영 장비", example = "오리발")
     private String item;
 
+    @Min(0)
     @Schema(description = "심박수", example = "129")
     private Short heartRate;
 
+    @Min(0)
     @Schema(description = "페이스 분", example = "5", maxLength = 2, type = "int")
     private int paceMinutes;
 
+    @Min(0)
     @Schema(description = "페이스 초", example = "30", maxLength = 2, type = "int")
     private int paceSeconds;
 
+    @Min(0)
     @Schema(description = "칼로리", example = "300")
     private Integer kcal;
 
@@ -47,6 +55,7 @@ public class MemoryUpdateRequest {
     @Schema(description = "수영 종료 시간", example = "11:50", maxLength = 5, type = "string")
     private LocalTime endTime;
 
+    @Min(0)
     @Schema(description = "레인 길이", example = "25")
     private Short lane;
 
@@ -54,6 +63,7 @@ public class MemoryUpdateRequest {
     private String diary;
 
     // Stroke
+    @Valid
     @Schema(description = "영법 목록")
     private List<StrokeUpdateRequest> strokes;
 
@@ -71,6 +81,7 @@ public class MemoryUpdateRequest {
             Short lane,
             String diary,
             List<StrokeUpdateRequest> strokes) {
+        validateTime();
         this.poolId = poolId;
         this.item = item;
         this.heartRate = heartRate;
@@ -83,5 +94,11 @@ public class MemoryUpdateRequest {
         this.lane = lane;
         this.diary = diary;
         this.strokes = strokes;
+    }
+
+    private void validateTime() {
+        if (startTime.isAfter(endTime)) {
+            throw new BadRequestException(MemoryErrorType.TIME_NOT_VALID);
+        }
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeCreateRequest.java
@@ -2,8 +2,9 @@ package com.depromeet.memory.dto.request;
 
 import com.depromeet.memory.annotation.HalfFloatCheck;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 
 public record StrokeCreateRequest(
         @Schema(description = "영법 이름", example = "자유형") String name,
-        @HalfFloatCheck @Schema(description = "바퀴 수", example = "3.5") Float laps,
-        @Schema(description = "미터", example = "150") Integer meter) {}
+        @Min(0) @HalfFloatCheck @Schema(description = "바퀴 수", example = "3.5") Float laps,
+        @Min(0) @Schema(description = "미터", example = "150") Integer meter) {}

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/StrokeUpdateRequest.java
@@ -2,9 +2,10 @@ package com.depromeet.memory.dto.request;
 
 import com.depromeet.memory.annotation.HalfFloatCheck;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 
 public record StrokeUpdateRequest(
         @Schema(description = "영법 Id", example = "1") Long id,
         @Schema(description = "영법 이름", example = "자유형") String name,
-        @HalfFloatCheck @Schema(description = "바퀴 수", example = "3.5") Float laps,
-        @Schema(description = "미터", example = "150") Integer meter) {}
+        @Min(0) @HalfFloatCheck @Schema(description = "바퀴 수", example = "3.5") Float laps,
+        @Min(0) @Schema(description = "미터", example = "150") Integer meter) {}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #303 

## 📌 작업 내용 및 특이사항
- stroke meter, laps, lane, pace, heartRate 등 숫자값 중 입력이 0 이하로도 가능해서 [@Min](https://jakarta.ee/specifications/bean-validation/3.0/apidocs/?jakarta/validation/constraints/Min.html) 어노테이션을 추가하였습니다

## 📝 참고사항
- 적용 결과
![image](https://github.com/user-attachments/assets/43eba5c9-034b-4dd0-9226-38feb8cdfdc5)
