### PR TITLE
feat: 기본 프로필 이미지인 경우 cloud front 도메인 제거 응답

### DIFF
--- a/module-domain/src/main/java/com/depromeet/friend/domain/vo/Follower.java
+++ b/module-domain/src/main/java/com/depromeet/friend/domain/vo/Follower.java
@@ -1,5 +1,6 @@
 package com.depromeet.friend.domain.vo;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,5 +31,21 @@ public class Follower {
         this.profileImageUrl = profileImageUrl;
         this.introduction = introduction;
         this.hasFollowedBack = hasFollowedBack;
+    }
+
+    public String getProfileImageUrl(String profileImageOrigin) {
+        if (profileImageUrl == null) {
+            return null;
+        } else if (isDefaultProfileNumber(profileImageUrl)) {
+            return profileImageUrl;
+        }
+        StringBuilder builder = new StringBuilder();
+        return builder.append(profileImageOrigin).append("/").append(profileImageUrl).toString();
+    }
+
+    private static final List<String> DEFAULT_IMAGE_NAMES = List.of("1", "2", "3", "4");
+
+    private static boolean isDefaultProfileNumber(String imageName) {
+        return DEFAULT_IMAGE_NAMES.contains(imageName);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/friend/domain/vo/Following.java
+++ b/module-domain/src/main/java/com/depromeet/friend/domain/vo/Following.java
@@ -1,5 +1,6 @@
 package com.depromeet.friend.domain.vo;
 
+import java.util.List;
 import lombok.*;
 
 @Getter
@@ -24,5 +25,21 @@ public class Following {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.introduction = introduction;
+    }
+
+    public String getProfileImageUrl(String profileImageOrigin) {
+        if (profileImageUrl == null) {
+            return null;
+        } else if (isDefaultProfileNumber(profileImageUrl)) {
+            return profileImageUrl;
+        }
+        StringBuilder builder = new StringBuilder();
+        return builder.append(profileImageOrigin).append("/").append(profileImageUrl).toString();
+    }
+
+    private static final List<String> DEFAULT_IMAGE_NAMES = List.of("1", "2", "3", "4");
+
+    private static boolean isDefaultProfileNumber(String imageName) {
+        return DEFAULT_IMAGE_NAMES.contains(imageName);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/member/domain/Member.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.depromeet.member.domain;
 
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -71,5 +72,21 @@ public class Member {
     public Member updateProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
         return this;
+    }
+
+    public String getProfileImageUrl(String profileImageOrigin) {
+        if (profileImageUrl == null) {
+            return null;
+        } else if (isDefaultProfileNumber(profileImageUrl)) {
+            return profileImageUrl;
+        }
+        StringBuilder builder = new StringBuilder();
+        return builder.append(profileImageOrigin).append("/").append(profileImageUrl).toString();
+    }
+
+    private static final List<String> DEFAULT_IMAGE_NAMES = List.of("1", "2", "3", "4");
+
+    private static boolean isDefaultProfileNumber(String imageName) {
+        return DEFAULT_IMAGE_NAMES.contains(imageName);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberSearchInfo.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberSearchInfo.java
@@ -1,5 +1,6 @@
 package com.depromeet.member.domain.vo;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,5 +26,21 @@ public class MemberSearchInfo {
         this.profileImageUrl = profileImageUrl;
         this.introduction = introduction;
         this.hasFollowed = hasFollowed;
+    }
+
+    public String getProfileImageUrl(String profileImageOrigin) {
+        if (profileImageUrl == null) {
+            return null;
+        } else if (isDefaultProfileNumber(profileImageUrl)) {
+            return profileImageUrl;
+        }
+        StringBuilder builder = new StringBuilder();
+        return builder.append(profileImageOrigin).append("/").append(profileImageUrl).toString();
+    }
+
+    private static final List<String> DEFAULT_IMAGE_NAMES = List.of("1", "2", "3", "4");
+
+    private static boolean isDefaultProfileNumber(String imageName) {
+        return DEFAULT_IMAGE_NAMES.contains(imageName);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
@@ -1,7 +1,6 @@
 package com.depromeet.followinglog.dto.response;
 
 import com.depromeet.followinglog.domain.FollowingMemoryLog;
-import com.depromeet.member.domain.Member;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.Stroke;
 import com.depromeet.memory.dto.response.StrokeResponse;
@@ -109,7 +108,7 @@ public record FollowingLogMemoryResponse(
         return FollowingLogMemoryResponse.builder()
                 .memberId(memory.getMember().getId())
                 .memberNickname(memory.getMember().getNickname())
-                .memberProfileUrl(getMemberProfileUrl(memory.getMember(), profileImageOrigin))
+                .memberProfileUrl(memory.getMember().getProfileImageUrl(profileImageOrigin))
                 .memoryId(memory.getId())
                 .recordAt(memory.getRecordAt().toString())
                 .startTime(memory.parseStartTime())
@@ -124,13 +123,6 @@ public record FollowingLogMemoryResponse(
                 .createdAt(followingMemoryLog.getCreatedAt())
                 .isRecentNews(isRecentNews)
                 .build();
-    }
-
-    private static String getMemberProfileUrl(Member member, String profileImageOrigin) {
-        if (member.getProfileImageUrl() != null) {
-            return profileImageOrigin + "/" + member.getProfileImageUrl();
-        }
-        return null;
     }
 
     private static Integer getKcalFromMemoryDetail(Memory memory) {

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
@@ -52,7 +52,7 @@ public record FollowSliceResponse<T>(
     }
 
     private static List<FollowingResponse> getFollowingResponses(
-            FollowSlice<Following> followingSlice, String profileImageDomain) {
+            FollowSlice<Following> followingSlice, String profileImageOrigin) {
         return followingSlice.getFollowContents().stream()
                 .map(
                         following ->
@@ -60,9 +60,7 @@ public record FollowSliceResponse<T>(
                                         .memberId(following.getMemberId())
                                         .name(following.getName())
                                         .profileImageUrl(
-                                                getProfileImageUrl(
-                                                        profileImageDomain,
-                                                        following.getProfileImageUrl()))
+                                                following.getProfileImageUrl(profileImageOrigin))
                                         .introduction(following.getIntroduction())
                                         .build())
                 .toList();
@@ -77,19 +75,10 @@ public record FollowSliceResponse<T>(
                                         .memberId(follower.getMemberId())
                                         .name(follower.getName())
                                         .profileImageUrl(
-                                                getProfileImageUrl(
-                                                        profileImageOrigin,
-                                                        follower.getProfileImageUrl()))
+                                                follower.getProfileImageUrl(profileImageOrigin))
                                         .introduction(follower.getIntroduction())
                                         .hasFollowedBack(follower.isHasFollowedBack())
                                         .build())
                 .toList();
-    }
-
-    private static String getProfileImageUrl(String profileImageOrigin, String profileImageUrl) {
-        if (profileImageUrl != null) {
-            return profileImageOrigin + "/" + profileImageUrl;
-        }
-        return null;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingResponse.java
@@ -35,16 +35,8 @@ public record FollowingResponse(
         return FollowingResponse.builder()
                 .memberId(following.getMemberId())
                 .name(following.getName())
-                .profileImageUrl(
-                        getProfileImageUrl(profileImageOrigin, following.getProfileImageUrl()))
+                .profileImageUrl(following.getProfileImageUrl(profileImageOrigin))
                 .introduction(following.getIntroduction())
                 .build();
-    }
-
-    private static String getProfileImageUrl(String profileImageOrigin, String profileImageUrl) {
-        if (profileImageUrl != null) {
-            return profileImageOrigin + "/" + profileImageUrl;
-        }
-        return null;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/image/facade/ImageFacade.java
@@ -57,12 +57,21 @@ public class ImageFacade {
         }
         // 전달 받은 이미지가 없는 경우 기존 이미지 삭제
         Member member = memberService.findById(memberId);
-        if (member.getProfileImageUrl() != null && !member.getProfileImageUrl().isBlank()) {
+        if (canDeleteImage(member.getProfileImageUrl())) {
             imageDeleteUseCase.deleteProfileImage(member.getProfileImageUrl());
         }
         // 멤버의 프로필 이미지 URL 정보를 수정한다
+        if (isDefaultProfileNumber(member.getProfileImageUrl())) {
+            return null;
+        }
         memberService.updateProfileImageUrl(memberId, null);
         return null;
+    }
+
+    private static boolean canDeleteImage(String profileImageUrl) {
+        return profileImageUrl != null
+                && !profileImageUrl.isBlank()
+                && !isDefaultProfileNumber(profileImageUrl);
     }
 
     public List<ImageUploadResponse> updateImages(
@@ -83,8 +92,8 @@ public class ImageFacade {
 
     public void changeProfileImageUrl(Long memberId, String imageName) {
         // 존재하는 이미지를 지운다
-        if (!isDefaultProfileNumber(imageName)) {
-            Member member = memberService.findById(memberId);
+        Member member = memberService.findById(memberId);
+        if (!isDefaultProfileNumber(member.getProfileImageUrl())) {
             if (member.getProfileImageUrl() != null && !member.getProfileImageUrl().isEmpty()) {
                 imageDeleteUseCase.deleteProfileImage(member.getProfileImageUrl());
             }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberDetailResponse.java
@@ -19,13 +19,6 @@ public record MemberDetailResponse(
                 member.getId(),
                 member.getNickname(),
                 member.getGoal(),
-                getProfileImageUrl(profileImageOrigin, member.getProfileImageUrl()));
-    }
-
-    private static String getProfileImageUrl(String profileImageOrigin, String profileImageUrl) {
-        if (profileImageUrl == null) {
-            return null;
-        }
-        return profileImageOrigin + "/" + profileImageUrl;
+                member.getProfileImageUrl(profileImageOrigin));
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberProfileResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberProfileResponse.java
@@ -39,16 +39,9 @@ public record MemberProfileResponse(
                 member.getId(),
                 member.getNickname(),
                 member.getIntroduction(),
-                getProfileImageUrl(profileImageOrigin, member.getProfileImageUrl()),
+                member.getProfileImageUrl(profileImageOrigin),
                 followerCount,
                 followingCount,
                 isMyProfile);
-    }
-
-    private static String getProfileImageUrl(String profileImageOrigin, String profileImageUrl) {
-        if (profileImageUrl == null) {
-            return null;
-        }
-        return profileImageOrigin + "/" + profileImageUrl;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSearchResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSearchResponse.java
@@ -27,7 +27,7 @@ public record MemberSearchResponse(
     }
 
     private static List<MemberInfoResponse> getMemberInfoResponses(
-            MemberSearchPage memberSearchPage, String profileImageDomain) {
+            MemberSearchPage memberSearchPage, String profileImageOrigin) {
         return memberSearchPage.getMembers().stream()
                 .map(
                         member ->
@@ -35,19 +35,10 @@ public record MemberSearchResponse(
                                         .memberId(member.getMemberId())
                                         .nickname(member.getNickname())
                                         .profileImageUrl(
-                                                getProfileImageUrl(
-                                                        profileImageDomain,
-                                                        member.getProfileImageUrl()))
+                                                member.getProfileImageUrl(profileImageOrigin))
                                         .introduction(member.getIntroduction())
                                         .hasFollowed(member.isHasFollowed())
                                         .build())
                 .toList();
-    }
-
-    private static String getProfileImageUrl(String profileImageDomain, String profileImageUrl) {
-        if (profileImageUrl == null) {
-            return null;
-        }
-        return profileImageDomain + "/" + profileImageUrl;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/notification/dto/response/FollowNotificationResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/dto/response/FollowNotificationResponse.java
@@ -1,6 +1,5 @@
 package com.depromeet.notification.dto.response;
 
-import com.depromeet.member.domain.Member;
 import com.depromeet.notification.domain.FollowLog;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDateTime;
@@ -36,17 +35,7 @@ public class FollowNotificationResponse extends BaseNotificationResponse {
                 "FOLLOW",
                 followLog.isHasRead(),
                 followLog.getFollower().getId(),
-                getImageUrl(profileImageOrigin, followLog.getFollower()),
+                followLog.getFollower().getProfileImageUrl(profileImageOrigin),
                 true);
-    }
-
-    private static String getImageUrl(String profileImageOrigin, Member follower) {
-        if (follower.getProfileImageUrl() == null) {
-            return null;
-        }
-
-        StringBuffer buffer = new StringBuffer();
-        buffer.append(profileImageOrigin).append("/").append(follower.getProfileImageUrl());
-        return buffer.toString();
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/notification/dto/response/FriendNotificationResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/dto/response/FriendNotificationResponse.java
@@ -1,6 +1,5 @@
 package com.depromeet.notification.dto.response;
 
-import com.depromeet.member.domain.Member;
 import com.depromeet.notification.domain.FollowLog;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.time.LocalDateTime;
@@ -33,16 +32,6 @@ public class FriendNotificationResponse extends BaseNotificationResponse {
                 "FRIEND",
                 followLog.isHasRead(),
                 followLog.getFollower().getId(),
-                getImageUrl(profileImageOrigin, followLog.getFollower()));
-    }
-
-    private static String getImageUrl(String profileImageOrigin, Member follower) {
-        if (follower.getProfileImageUrl() == null) {
-            return null;
-        }
-
-        StringBuffer buffer = new StringBuffer();
-        buffer.append(profileImageOrigin).append("/").append(follower.getProfileImageUrl());
-        return buffer.toString();
+                followLog.getFollower().getProfileImageUrl(profileImageOrigin));
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/reaction/dto/response/MemoryReactionResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/dto/response/MemoryReactionResponse.java
@@ -9,7 +9,8 @@ import java.util.List;
 public record MemoryReactionResponse(
         @Schema(description = "응원 리스트", requiredMode = Schema.RequiredMode.REQUIRED)
                 List<ReactionDetailResponse> reactions) {
-    public static MemoryReactionResponse from(List<Reaction> reactionDomains) {
+    public static MemoryReactionResponse from(
+            List<Reaction> reactionDomains, String profileImageOrigin) {
         return new MemoryReactionResponse(
                 reactionDomains.stream()
                         .map(
@@ -20,13 +21,8 @@ public record MemoryReactionResponse(
                                                 it.getComment(),
                                                 it.getMember().getId(),
                                                 it.getMember().getNickname(),
-                                                getProfileImageUrl(it)))
+                                                it.getMember()
+                                                        .getProfileImageUrl(profileImageOrigin)))
                         .toList());
-    }
-
-    private static String getProfileImageUrl(Reaction reaction) {
-        return reaction.getMember().getProfileImageUrl() != null
-                ? reaction.getMember().getProfileImageUrl()
-                : null;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/reaction/dto/response/PagingReactionResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/dto/response/PagingReactionResponse.java
@@ -21,9 +21,12 @@ public record PagingReactionResponse(
                         example = "true",
                         requiredMode = Schema.RequiredMode.REQUIRED)
                 boolean hasNext) {
-    public static PagingReactionResponse of(ReactionPage page, Long totalCount) {
+    public static PagingReactionResponse of(
+            ReactionPage page, Long totalCount, String profileImageOrigin) {
         return new PagingReactionResponse(
-                page.getReactions().stream().map(ReactionDetailResponse::from).toList(),
+                page.getReactions().stream()
+                        .map(it -> ReactionDetailResponse.from(it, profileImageOrigin))
+                        .toList(),
                 totalCount,
                 page.getCursorId(),
                 page.isHasNext());

--- a/module-presentation/src/main/java/com/depromeet/reaction/dto/response/ReactionDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/dto/response/ReactionDetailResponse.java
@@ -27,13 +27,13 @@ public record ReactionDetailResponse(
                         example = "https://url.com",
                         requiredMode = Schema.RequiredMode.REQUIRED)
                 String profileImageUrl) {
-    public static ReactionDetailResponse from(Reaction reaction) {
+    public static ReactionDetailResponse from(Reaction reaction, String profileImageOrigin) {
         return new ReactionDetailResponse(
                 reaction.getId(),
                 reaction.getEmoji(),
                 reaction.getComment(),
                 reaction.getMember().getId(),
                 reaction.getMember().getNickname(),
-                reaction.getMember().getProfileImageUrl());
+                reaction.getMember().getProfileImageUrl(profileImageOrigin));
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/reaction/facade/ReactionFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/facade/ReactionFacade.java
@@ -15,6 +15,7 @@ import com.depromeet.reaction.port.in.usecase.DeleteReactionUseCase;
 import com.depromeet.reaction.port.in.usecase.GetReactionUseCase;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +33,9 @@ public class ReactionFacade {
 
     private static final int MAXIMUM_REACTION_NUMBER = 3;
 
+    @Value("${cloud-front.domain}")
+    private String profileImageOrigin;
+
     @Transactional
     public void create(Long memberId, ReactionCreateRequest request) {
         Memory memory = getMemoryUseCase.findByIdWithMember(request.memoryId());
@@ -42,13 +46,13 @@ public class ReactionFacade {
 
     public MemoryReactionResponse getReactionsOfMemory(Long memoryId) {
         List<Reaction> reactionDomains = getReactionUseCase.getReactionsOfMemory(memoryId);
-        return MemoryReactionResponse.from(reactionDomains);
+        return MemoryReactionResponse.from(reactionDomains, profileImageOrigin);
     }
 
     public PagingReactionResponse getDetailReactions(Long memoryId, Long cursorId) {
         ReactionPage page = getReactionUseCase.getDetailReactions(memoryId, cursorId);
         Long totalCount = getReactionUseCase.getDetailReactionsCount(memoryId);
-        return PagingReactionResponse.of(page, totalCount);
+        return PagingReactionResponse.of(page, totalCount, profileImageOrigin);
     }
 
     @Transactional


### PR DESCRIPTION
## 🌱 관련 이슈

- close #307

## 📌 작업 내용 및 특이사항
- 기본 프로필 이미지인 경우 cloud front 도메인을 붙이지 않고 응답할 수 있도록 구현하였습니다.
- 관련된 다른 코드들도 전면 수정된 부분이 많습니다.

## 📝 참고사항
- 기본 프로필인 경우 (1, 2, 3, 4)
<img width="843" alt="Screenshot 2024-08-28 at 23 44 15" src="https://github.com/user-attachments/assets/02dbc682-5152-4c0b-90e7-c27a843c511e">

- 아닌 경우
<img width="847" alt="Screenshot 2024-08-28 at 23 44 54" src="https://github.com/user-attachments/assets/489193bb-2a95-41e5-8b68-0fb3189fb0d5">