### PR TITLE
fix: 회원 탈퇴 시 log 삭제 누락 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/DeleteReactionUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/DeleteReactionUseCase.java
@@ -1,7 +1,9 @@
 package com.depromeet.reaction.port.in.usecase;
 
+import java.util.List;
+
 public interface DeleteReactionUseCase {
     void deleteById(Long memberId, Long reactionId);
 
-    void deleteByMemberId(Long memberId);
+    void deleteByIds(List<Long> reactionIds);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/DeleteReactionUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/DeleteReactionUseCase.java
@@ -5,5 +5,5 @@ import java.util.List;
 public interface DeleteReactionUseCase {
     void deleteById(Long memberId, Long reactionId);
 
-    void deleteByIds(List<Long> reactionIds);
+    void deleteAllById(List<Long> reactionIds);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
@@ -23,5 +23,5 @@ public interface ReactionPersistencePort {
 
     List<Long> findAllIdByMemoryIdOrMemberId(List<Long> memoryIds, Long memberId);
 
-    void deleteByIds(List<Long> reactionIds);
+    void deleteAllById(List<Long> reactionIds);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
@@ -19,9 +19,9 @@ public interface ReactionPersistencePort {
 
     void deleteById(Long reactionId);
 
-    void deleteByMemberId(Long memberId);
-
     List<Reaction> getPureReactionsByMemberAndMemory(Long memberId, Long memoryId);
 
     List<Long> findAllIdByMemoryIdOrMemberId(List<Long> memoryIds, Long memberId);
+
+    void deleteByIds(List<Long> reactionIds);
 }

--- a/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
@@ -65,8 +65,8 @@ public class ReactionService
     }
 
     @Override
-    public void deleteByIds(List<Long> reactionIds) {
-        reactionPersistencePort.deleteByIds(reactionIds);
+    public void deleteAllById(List<Long> reactionIds) {
+        reactionPersistencePort.deleteAllById(reactionIds);
     }
 
     @Override

--- a/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
@@ -65,8 +65,8 @@ public class ReactionService
     }
 
     @Override
-    public void deleteByMemberId(Long memberId) {
-        reactionPersistencePort.deleteByMemberId(memberId);
+    public void deleteByIds(List<Long> reactionIds) {
+        reactionPersistencePort.deleteByIds(reactionIds);
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
@@ -62,6 +62,11 @@ public class ReactionRepository implements ReactionPersistencePort {
                 .fetch();
     }
 
+    @Override
+    public void deleteByIds(List<Long> reactionIds) {
+        queryFactory.delete(reactionEntity).where(reactionEntity.id.in(reactionIds)).execute();
+    }
+
     private static BooleanExpression memoryIn(List<Long> memoryIds) {
         if (memoryIds == null) {
             return null;
@@ -131,11 +136,6 @@ public class ReactionRepository implements ReactionPersistencePort {
     @Override
     public void deleteById(Long reactionId) {
         reactionJpaRepository.deleteById(reactionId);
-    }
-
-    @Override
-    public void deleteByMemberId(Long memberId) {
-        reactionJpaRepository.deleteByMemberId(memberId);
     }
 
     private BooleanExpression memberEq(Long memberId) {

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
@@ -63,7 +63,7 @@ public class ReactionRepository implements ReactionPersistencePort {
     }
 
     @Override
-    public void deleteByIds(List<Long> reactionIds) {
+    public void deleteAllById(List<Long> reactionIds) {
         queryFactory.delete(reactionEntity).where(reactionEntity.id.in(reactionIds)).execute();
     }
 

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -126,10 +126,10 @@ public class AuthFacade {
         // Reaction 조회
         List<Long> reactionIds =
                 getReactionUseCase.findAllIdByMemoryIdOrMemberId(memoryIds, memberId);
-        // Reaction 삭제
-        deleteReactionUseCase.deleteByMemberId(memberId);
         // Reaction log 삭제
         deleteReactionLogUseCase.deleteAllById(reactionIds);
+        // Reaction 삭제
+        deleteReactionUseCase.deleteByIds(reactionIds);
         // Stroke 삭제
         strokeUseCase.deleteAllByMemoryId(memoryIds);
         // Image FK Null

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -126,10 +126,10 @@ public class AuthFacade {
         // Reaction 조회
         List<Long> reactionIds =
                 getReactionUseCase.findAllIdByMemoryIdOrMemberId(memoryIds, memberId);
-        // Reaction log 삭제
-        deleteReactionLogUseCase.deleteAllById(reactionIds);
         // Reaction 삭제
         deleteReactionUseCase.deleteByMemberId(memberId);
+        // Reaction log 삭제
+        deleteReactionLogUseCase.deleteAllById(reactionIds);
         // Stroke 삭제
         strokeUseCase.deleteAllByMemoryId(memoryIds);
         // Image FK Null

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -129,7 +129,7 @@ public class AuthFacade {
         // Reaction log 삭제
         deleteReactionLogUseCase.deleteAllById(reactionIds);
         // Reaction 삭제
-        deleteReactionUseCase.deleteByIds(reactionIds);
+        deleteReactionUseCase.deleteAllById(reactionIds);
         // Stroke 삭제
         strokeUseCase.deleteAllByMemoryId(memoryIds);
         // Image FK Null


### PR DESCRIPTION
## 🌱 관련 이슈

- close #312

## 📌 작업 내용 및 특이사항
- 회원 탈퇴 시 reaction 삭제 누락 오류를 수정하였습니다.
- 기존에는 memberId에 해당하는 reaction만 삭제했다면, 이제는 탈퇴하고자 하는 사용자의 memory와 관련된 reaction도 삭제되게 수정하였습니다.