### PR TITLE
fix: 팔로잉/팔로우 리스트 응답값에서 name 필드명 nickname으로 변경

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
@@ -58,7 +58,7 @@ public record FollowSliceResponse<T>(
                         following ->
                                 FollowingResponse.builder()
                                         .memberId(following.getMemberId())
-                                        .name(following.getName())
+                                        .nickname(following.getName())
                                         .profileImageUrl(
                                                 getProfileImageUrl(
                                                         profileImageDomain,
@@ -75,7 +75,7 @@ public record FollowSliceResponse<T>(
                         follower ->
                                 FollowerResponse.builder()
                                         .memberId(follower.getMemberId())
-                                        .name(follower.getName())
+                                        .nickname(follower.getName())
                                         .profileImageUrl(
                                                 getProfileImageUrl(
                                                         profileImageOrigin,

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowerResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowerResponse.java
@@ -15,7 +15,7 @@ public record FollowerResponse(
                         description = "팔로워 member nickname",
                         example = "홍길동",
                         requiredMode = Schema.RequiredMode.REQUIRED)
-                String name,
+                String nickname,
         @Schema(
                         description = "팔로워 프로필 사진 url",
                         example = "https://image.webp",

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingResponse.java
@@ -16,7 +16,7 @@ public record FollowingResponse(
                         description = "팔로잉 member 이름",
                         example = "홍길동",
                         requiredMode = Schema.RequiredMode.REQUIRED)
-                String name,
+                String nickname,
         @Schema(
                         description = "팔로잉 member 프로필 사진 url",
                         example = "https://image.webp",
@@ -34,7 +34,7 @@ public record FollowingResponse(
             Following following, String profileImageOrigin) {
         return FollowingResponse.builder()
                 .memberId(following.getMemberId())
-                .name(following.getName())
+                .nickname(following.getName())
                 .profileImageUrl(
                         getProfileImageUrl(profileImageOrigin, following.getProfileImageUrl()))
                 .introduction(following.getIntroduction())


### PR DESCRIPTION
## 🌱 관련 이슈

- close #313 

## 📌 작업 내용 및 특이사항
- 팔로잉/팔로우 리스트 응답값 member name -> nickname으로 통일해달라는 요청반영
![image](https://github.com/user-attachments/assets/abd8537c-c363-49b4-b658-418502287382)


## 📝 참고사항
- 결과

팔로잉 리스트
![image](https://github.com/user-attachments/assets/2a2a03fa-8258-4c4f-ac7a-442879d0ec50)


팔로워 리스트
![image](https://github.com/user-attachments/assets/34a6ecef-3798-4787-b5b6-ee195997bde1)
