### PR TITLE
fix: Reaction log 삭제 시 조건절 오류 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/notification/port/in/usecase/DeleteReactionLogUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/in/usecase/DeleteReactionLogUseCase.java
@@ -3,5 +3,5 @@ package com.depromeet.notification.port.in.usecase;
 import java.util.List;
 
 public interface DeleteReactionLogUseCase {
-    void deleteAllById(List<Long> reactionLogIds);
+    void deleteAllByReactionId(List<Long> reactionIds);
 }

--- a/module-domain/src/main/java/com/depromeet/notification/port/out/ReactionLogPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/out/ReactionLogPersistencePort.java
@@ -14,5 +14,5 @@ public interface ReactionLogPersistencePort {
 
     Long countUnread(Long memberId);
 
-    void deleteAllById(List<Long> reactionLogIds);
+    void deleteAllByReactionId(List<Long> reactionIds);
 }

--- a/module-domain/src/main/java/com/depromeet/notification/service/ReactionLogService.java
+++ b/module-domain/src/main/java/com/depromeet/notification/service/ReactionLogService.java
@@ -48,7 +48,7 @@ public class ReactionLogService
     }
 
     @Override
-    public void deleteAllById(List<Long> reactionLogIds) {
-        reactionLogPersistencePort.deleteAllById(reactionLogIds);
+    public void deleteAllByReactionId(List<Long> reactionIds) {
+        reactionLogPersistencePort.deleteAllByReactionId(reactionIds);
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/ReactionLogRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/ReactionLogRepository.java
@@ -73,15 +73,15 @@ public class ReactionLogRepository implements ReactionLogPersistencePort {
     }
 
     @Override
-    public void deleteAllById(List<Long> reactionLogIds) {
-        queryFactory.delete(reactionLogEntity).where(idIn(reactionLogIds)).execute();
+    public void deleteAllByReactionId(List<Long> reactionIds) {
+        queryFactory.delete(reactionLogEntity).where(reactionIdIn(reactionIds)).execute();
     }
 
-    private static BooleanExpression idIn(List<Long> reactionLogIds) {
-        if (reactionLogIds == null) {
+    private static BooleanExpression reactionIdIn(List<Long> reactionIds) {
+        if (reactionIds == null) {
             return null;
         }
-        return reactionLogEntity.id.in(reactionLogIds);
+        return reactionLogEntity.reaction.id.in(reactionIds);
     }
 
     private ReactionLogEntity findByMemberIdAndLogId(Long memberId, Long reactionLogId) {

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -127,7 +127,7 @@ public class AuthFacade {
         List<Long> reactionIds =
                 getReactionUseCase.findAllIdByMemoryIdOrMemberId(memoryIds, memberId);
         // Reaction log 삭제
-        deleteReactionLogUseCase.deleteAllById(reactionIds);
+        deleteReactionLogUseCase.deleteAllByReactionId(reactionIds);
         // Reaction 삭제
         deleteReactionUseCase.deleteAllById(reactionIds);
         // Stroke 삭제


### PR DESCRIPTION
## 🌱 관련 이슈

- close #312

## 📌 작업 내용 및 특이사항
- Reaction log 삭제 시 조건절에서 reaction_log.reaction.id가 아닌 reaction_log.id를 비교하고 있어서 reaction_log가 삭제되지 않았고 참조 오류가 발생했습니다.