### PR TITLE
fix: 팔로잉 소식 응답값 필드명 변경(memberProfileUrl -> profileImageUrl)

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
@@ -28,7 +28,7 @@ public record FollowingLogMemoryResponse(
                         description = "member 프로필 url",
                         example = "https://presignedUrl/image.webp",
                         requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-                String memberProfileUrl,
+                String profileImageUrl,
         @Schema(
                         description = "memory PK",
                         example = "1",
@@ -108,7 +108,7 @@ public record FollowingLogMemoryResponse(
         return FollowingLogMemoryResponse.builder()
                 .memberId(memory.getMember().getId())
                 .memberNickname(memory.getMember().getNickname())
-                .memberProfileUrl(memory.getMember().getProfileImageUrl(profileImageOrigin))
+                .profileImageUrl(memory.getMember().getProfileImageUrl(profileImageOrigin))
                 .memoryId(memory.getId())
                 .recordAt(memory.getRecordAt().toString())
                 .startTime(memory.parseStartTime())


### PR DESCRIPTION
## 🌱 관련 이슈

- close #319 

## 📌 작업 내용 및 특이사항
- 팔로우 소식의 팔로우 유저 프로필 url 필드명을 memberProfileUrl -> profileImageUrl로 변경하였습니다.

## 📝 참고사항
결과
![240829](https://github.com/user-attachments/assets/eede1cd4-75f1-433b-94fb-e3c0b04055cd)

