### PR TITLE
feat: 애플 로그인 요청 객체 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/in/usecase/SocialUseCase.java
@@ -1,5 +1,6 @@
 package com.depromeet.auth.port.in.usecase;
 
+import com.depromeet.auth.vo.apple.AppleAccountCommand;
 import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 import com.depromeet.dto.auth.AccountProfileResponse;
 
@@ -8,7 +9,8 @@ public interface SocialUseCase {
 
     KakaoAccountProfile getKakaoAccountProfile(String code, String origin);
 
-    AccountProfileResponse getAppleAccountToken(String code, String origin);
+    AccountProfileResponse getAppleAccountToken(
+            AppleAccountCommand appleAccountCommand, String origin);
 
     void revokeAccount(String accountType);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/port/out/ApplePort.java
+++ b/module-domain/src/main/java/com/depromeet/auth/port/out/ApplePort.java
@@ -1,9 +1,11 @@
 package com.depromeet.auth.port.out;
 
+import com.depromeet.auth.vo.apple.AppleAccountCommand;
 import com.depromeet.dto.auth.AccountProfileResponse;
 
 public interface ApplePort {
-    AccountProfileResponse getAppleAccountToken(String code, String origin);
+    AccountProfileResponse getAppleAccountToken(
+            AppleAccountCommand appleAccountCommand, String origin);
 
     void revokeAccount(String providerId);
 }

--- a/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
+++ b/module-domain/src/main/java/com/depromeet/auth/service/SocialService.java
@@ -4,6 +4,7 @@ import com.depromeet.auth.port.in.usecase.SocialUseCase;
 import com.depromeet.auth.port.out.ApplePort;
 import com.depromeet.auth.port.out.GooglePort;
 import com.depromeet.auth.port.out.KakaoPort;
+import com.depromeet.auth.vo.apple.AppleAccountCommand;
 import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 import com.depromeet.dto.auth.AccountProfileResponse;
 import com.depromeet.exception.NotFoundException;
@@ -31,8 +32,9 @@ public class SocialService implements SocialUseCase {
     }
 
     @Override
-    public AccountProfileResponse getAppleAccountToken(String code, String origin) {
-        return applePort.getAppleAccountToken(code, origin);
+    public AccountProfileResponse getAppleAccountToken(
+            AppleAccountCommand appleAccountCommand, String origin) {
+        return applePort.getAppleAccountToken(appleAccountCommand, origin);
     }
 
     @Override

--- a/module-domain/src/main/java/com/depromeet/auth/vo/apple/AppleAccountCommand.java
+++ b/module-domain/src/main/java/com/depromeet/auth/vo/apple/AppleAccountCommand.java
@@ -1,0 +1,20 @@
+package com.depromeet.auth.vo.apple;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AppleAccountCommand {
+    private String fullName;
+    private String email;
+    private final String code;
+    private final String idToken;
+
+    @Builder
+    public AppleAccountCommand(String fullName, String email, String code, String idToken) {
+        this.fullName = fullName;
+        this.email = email;
+        this.code = code;
+        this.idToken = idToken;
+    }
+}

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
@@ -2,6 +2,7 @@ package com.depromeet.util;
 
 import com.depromeet.auth.port.out.ApplePort;
 import com.depromeet.auth.port.out.persistence.SocialRedisPersistencePort;
+import com.depromeet.auth.vo.apple.AppleAccountCommand;
 import com.depromeet.dto.auth.AccountProfileResponse;
 import com.depromeet.exception.BadRequestException;
 import com.depromeet.exception.InternalServerException;
@@ -77,8 +78,10 @@ public class AppleClient implements ApplePort {
     private final SocialRedisPersistencePort socialRedisPersistencePort;
 
     @Override
-    public AccountProfileResponse getAppleAccountToken(String code, String origin) {
-        final AppleTokenResponse appleTokenResponse = requestTokens(code, origin);
+    public AccountProfileResponse getAppleAccountToken(
+            AppleAccountCommand appleAccountCommand, String origin) {
+        final AppleTokenResponse appleTokenResponse =
+                requestTokens(appleAccountCommand.getCode(), origin);
         if (appleTokenResponse == null) {
             throw new BadRequestException(AuthErrorType.LOGIN_FAILED);
         }
@@ -100,7 +103,9 @@ public class AppleClient implements ApplePort {
         socialRedisPersistencePort.setRTData(
                 payload.getSubject(), appleTokenResponse.refreshToken(), RTExpireTime);
         return new AccountProfileResponse(
-                payload.getSubject(), "김스위미", payload.get("email", String.class));
+                payload.getSubject(),
+                appleAccountCommand.getFullName(),
+                appleAccountCommand.getEmail());
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleAccountInfo.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleAccountInfo.java
@@ -1,0 +1,9 @@
+package com.depromeet.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AppleAccountInfo(
+        @Schema(description = "성명", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                AppleNameInfo name,
+        @Schema(description = "이메일", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String email) {}

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleLoginRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleLoginRequest.java
@@ -1,5 +1,14 @@
 package com.depromeet.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
-public record AppleLoginRequest(@NotNull(message = "인가 코드는 null일 수 없습니다") String code) {}
+public record AppleLoginRequest(
+        @Schema(description = "회원 정보", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                AppleAccountInfo user,
+        @NotNull(message = "인가 코드는 null일 수 없습니다")
+                @Schema(description = "인가 코드", requiredMode = Schema.RequiredMode.REQUIRED)
+                String code,
+        @NotNull(message = "ID 토큰은 null일 수 없습니다")
+                @Schema(description = "ID 토큰", requiredMode = Schema.RequiredMode.REQUIRED)
+                String idToken) {}

--- a/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleNameInfo.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/dto/request/AppleNameInfo.java
@@ -1,0 +1,9 @@
+package com.depromeet.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AppleNameInfo(
+        @Schema(description = "이름", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String firstName,
+        @Schema(description = "성", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String lastName) {}

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -5,6 +5,7 @@ import com.depromeet.auth.dto.request.GoogleLoginRequest;
 import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
 import com.depromeet.auth.dto.response.JwtTokenResponse;
+import com.depromeet.auth.mapper.AppleMapper;
 import com.depromeet.auth.port.in.usecase.CreateTokenUseCase;
 import com.depromeet.auth.port.in.usecase.SocialUseCase;
 import com.depromeet.auth.vo.AccessTokenInfo;
@@ -80,7 +81,8 @@ public class AuthFacade {
 
     public JwtTokenResponse loginByApple(AppleLoginRequest request) {
         final AccountProfileResponse profile =
-                socialUseCase.getAppleAccountToken(request.code(), "https://swimie.life");
+                socialUseCase.getAppleAccountToken(
+                        AppleMapper.toCommand(request), "https://swimie.life");
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }
@@ -88,7 +90,7 @@ public class AuthFacade {
     }
 
     private JwtTokenResponse getJwtTokenResponse(AccountProfileResponse profile, String provider) {
-        Boolean isSignUpComplete = true;
+        boolean isSignUpComplete = true;
         String providerId = provider + " " + profile.id();
         Member member = memberUseCase.findByProviderId(providerId);
         if (member == null) {

--- a/module-presentation/src/main/java/com/depromeet/auth/mapper/AppleMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/mapper/AppleMapper.java
@@ -1,0 +1,22 @@
+package com.depromeet.auth.mapper;
+
+import com.depromeet.auth.dto.request.AppleLoginRequest;
+import com.depromeet.auth.vo.apple.AppleAccountCommand;
+
+public class AppleMapper {
+    public static AppleAccountCommand toCommand(AppleLoginRequest request) {
+        if (request.user() != null) {
+            return AppleAccountCommand.builder()
+                    .fullName(request.user().name().firstName() + request.user().name().lastName())
+                    .email(request.user().email())
+                    .code(request.code())
+                    .idToken(request.idToken())
+                    .build();
+        } else {
+            return AppleAccountCommand.builder()
+                    .code(request.code())
+                    .idToken(request.idToken())
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #323

## 📌 작업 내용 및 특이사항
- 애플 로그인 요청 객체를 수정하였습니다.
- 애플 로그인은 처음 승인되었을 때 단 한 번 계정의 이름과 이메일 정보를 POST 방식으로 제공합니다.
![image](https://github.com/user-attachments/assets/0f3c44bb-bdea-4abf-ba98-fc148a4aebd3)
- 클라이언트에서 이 데이터를 body로 받아 우리 서버로 전해주게 됩니다.
- 이후 로그인 시에는 계정의 이름과 이메일 정보 없이, code와 idToken만 제공하게 됩니다.

## 📝 참고사항
- 첫 로그인 성공 시
<img width="1330" alt="Screenshot 2024-08-29 at 21 30 03" src="https://github.com/user-attachments/assets/ba43b992-bf97-4957-bab3-44bcd02a075b">
<img width="741" alt="Screenshot 2024-08-29 at 21 26 29" src="https://github.com/user-attachments/assets/599d0733-44cb-44e8-a0a9-4c5361fca466">

- 이후 로그인 성공 시
<img width="1503" alt="Screenshot 2024-08-29 at 21 24 23" src="https://github.com/user-attachments/assets/0a011d1c-9829-487d-a7ed-db13ff042311">
<img width="842" alt="Screenshot 2024-08-29 at 21 24 10" src="https://github.com/user-attachments/assets/f1ec8ec4-a8f7-4006-bd40-fcb4c29befb5">

- Redis에 저장되는 애플 서버 AT, RT
<img width="493" alt="Screenshot 2024-08-29 at 21 22 50" src="https://github.com/user-attachments/assets/22fb203b-1761-4c44-837f-b58ee9e9ac32">