### PR TITLE
fix: 애플 로그인 파일 읽기 안 되는 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 **/application-secret.properties
 **/data.sql
 generated
+**/Swimie_AuthKey_B52ZG9MWCW.p8
 
 ### STS ###
 .apt_generated

--- a/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
+++ b/module-infrastructure/security/src/main/java/com/depromeet/util/AppleClient.java
@@ -16,12 +16,13 @@ import com.depromeet.type.common.CommonErrorType;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
 import io.jsonwebtoken.*;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
+
+import java.io.*;
 import java.math.BigInteger;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -40,6 +41,7 @@ import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.PEMParser;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -187,7 +189,15 @@ public class AppleClient implements ApplePort {
     }
 
     private PrivateKey getPrivateKey() throws IOException {
-        Reader pemReader = new StringReader(appleSignKey);
+        File keyFile = new File(appleSignKey);
+        FileReader reader = new FileReader(keyFile);
+        StringBuilder privateKey = new StringBuilder();
+        int singleCh = 0;
+        while ((singleCh = reader.read()) != -1) {
+            privateKey.append((char) singleCh);
+        }
+        reader.close();
+        Reader pemReader = new StringReader(privateKey.toString());
         PEMParser pemParser = new PEMParser(pemReader);
         JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
         PrivateKeyInfo object = (PrivateKeyInfo) pemParser.readObject();

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -82,7 +82,7 @@ public class AuthFacade {
     public JwtTokenResponse loginByApple(AppleLoginRequest request) {
         final AccountProfileResponse profile =
                 socialUseCase.getAppleAccountToken(
-                        AppleMapper.toCommand(request), "https://swimie.life");
+                        AppleMapper.toCommand(request), "https://unduly-light-chimp.ngrok-free.app");
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #323

## 📌 작업 내용 및 특이사항
- 애플 로그인 진행 시 키 파일 내용을 환경변수에 추가하여 진행했었는데, 배포 서버에서는 이 값을 읽어오지 못했습니다.