### PR TITLE
fix: 팔로잉 소식 멤버 이름 변수명 수정

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
@@ -23,7 +23,7 @@ public record FollowingLogMemoryResponse(
                         description = "member 이름(팔로잉 이름)",
                         example = "김민석",
                         requiredMode = Schema.RequiredMode.REQUIRED)
-                String memberNickname,
+                String nickname,
         @Schema(
                         description = "member 프로필 url",
                         example = "https://presignedUrl/image.webp",
@@ -107,7 +107,7 @@ public record FollowingLogMemoryResponse(
 
         return FollowingLogMemoryResponse.builder()
                 .memberId(memory.getMember().getId())
-                .memberNickname(memory.getMember().getNickname())
+                .nickname(memory.getMember().getNickname())
                 .profileImageUrl(memory.getMember().getProfileImageUrl(profileImageOrigin))
                 .memoryId(memory.getId())
                 .recordAt(memory.getRecordAt().toString())


### PR DESCRIPTION


## 📌 작업 내용 및 특이사항
- 팔로잉 소식에서 memberNickname -> nickname으로 필드명 변경