### PR TITLE
fix: 팔로잉 여부 조회 시 자신의 계정을 조회하는 경우 에러 제거

### DIFF
--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -74,9 +74,6 @@ public class FollowService implements FollowUseCase {
 
     @Override
     public List<FollowCheck> isFollowing(Long memberId, List<Long> targetMemberId) {
-        if (targetMemberId != null && targetMemberId.contains(memberId)) {
-            throw new BadRequestException(FollowErrorType.SELF_FOLLOWING_NOT_ALLOWED);
-        }
         return friendPersistencePort.findByMemberIdAndFollowingIds(memberId, targetMemberId);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #336

## 📌 작업 내용 및 특이사항
[As-is]
서버: 자신의 프로필을 포함해서 보내면 에러 출력
클라이언트: 프로필 목록에 자신이 포함되어 있으면 팔로잉/팔로우 버튼 제외하여 클릭할 수 없도록 예외처리
[To-be]
서버: 자신의 프로필을 포함하여 목록을 조회해도, 다른 목록들의 여부 값을 알 수 있도록 api 수정
클라이언트: 프로필 목록에 자신이 포함되어 있으면 팔로잉/팔로우 버튼 제외하여 클릭할 수 없도록 예외처리

## 📝 참고사항
- 성공 응답
<img width="846" alt="Screenshot 2024-08-30 at 15 16 51" src="https://github.com/user-attachments/assets/6e68af38-91af-4ac3-b962-a08855f40b12">