### PR TITLE
fix: 구글 스프레드 시트 json 읽어오는 클래스 FileInputStream으로 변경

### DIFF
--- a/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/spreadsheet/GoogleSheetManager.java
+++ b/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/spreadsheet/GoogleSheetManager.java
@@ -15,6 +15,7 @@ import com.google.api.services.sheets.v4.model.AppendValuesResponse;
 import com.google.api.services.sheets.v4.model.ValueRange;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.time.LocalDateTime;
@@ -24,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -63,8 +63,7 @@ public class GoogleSheetManager implements WithdrawalReasonPort {
     private Sheets getSheetService() throws IOException, GeneralSecurityException {
         GoogleCredentials googleCredentials =
                 GoogleCredentials.fromStream(
-                                new ClassPathResource(spreadSheetProperties.credentialsFilePath())
-                                        .getInputStream())
+                                new FileInputStream(spreadSheetProperties.credentialsFilePath()))
                         .createScoped(SCOPES);
         return new Sheets.Builder(
                         GoogleNetHttpTransport.newTrustedTransport(),


### PR DESCRIPTION
## 🌱 관련 이슈

- close #338 

## 📌 작업 내용 및 특이사항
- 구글 스프레드 시트 credential json 파일을 읽어오는 클래스를 ClassPathResource에서 FileInputStream으로 변경했습니다.
- 현재 ClassPathResource 를 사용한 코드도 정상 작동하지만 ClassPathResource는 기본적으로 Classpath를 기준으로 파일을 읽어오는 클래스이므로 정석적으로 외부 파일을 읽어오려면 FileInputStream 을 활용하는게 맞다고 판단하여 변경하였습니다.
