### PR TITLE
refactor: 디바운싱 로직 변경

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/common/DuplicateRequestAspect.java
+++ b/module-presentation/src/main/java/com/depromeet/common/DuplicateRequestAspect.java
@@ -3,26 +3,31 @@ package com.depromeet.common;
 import static java.util.concurrent.TimeUnit.*;
 
 import com.depromeet.exception.BaseException;
+import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.type.common.CommonErrorType;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
+@Slf4j
 @Aspect
 @Component
 public class DuplicateRequestAspect {
-    private Set<String> requestSet = Collections.synchronizedSet(new HashSet<>());
+    private Set<String> requestSet = new ConcurrentSkipListSet<>();
     private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     @Pointcut("within(*..*Controller)")
@@ -39,19 +44,58 @@ public class DuplicateRequestAspect {
             return joinPoint.proceed();
         }
 
-        String requestId = joinPoint.getSignature().toLongString();
+        String requestURI = request.getRequestURI();
+        String userId = getUserIdFromSecurityContext();
+
+        String requestId = userId + joinPoint.getSignature().toLongString();
+        requestId = handleWhitelist(joinPoint, requestURI, requestId);
+
         if (requestSet.contains(requestId)) {
             handleDuplicateRequest();
         }
         requestSet.add(requestId);
+
         try {
             return joinPoint.proceed();
         } finally {
-            scheduler.schedule(() -> requestSet.remove(requestId), 1, SECONDS);
+            final String finalRequestId = requestId;
+            scheduler.schedule(() -> requestSet.remove(finalRequestId), 1, SECONDS);
         }
+    }
+
+    private String handleWhitelist(
+            ProceedingJoinPoint joinPoint, String requestURI, String requestId) {
+        if (requestURI.equals("/friend")) {
+            Object[] args = joinPoint.getArgs();
+            Object requestBody = null;
+
+            for (Object arg : args) {
+                if (arg instanceof FollowRequest) {
+                    requestBody = arg;
+                    break;
+                }
+            }
+
+            if (requestBody != null) {
+                FollowRequest requests = (FollowRequest) requestBody;
+                requestId += requests.followingId().toString();
+            }
+        }
+        return requestId;
     }
 
     private void handleDuplicateRequest() {
         throw new BaseException(CommonErrorType.TOO_MANY_REQUESTS, HttpStatus.TOO_MANY_REQUESTS);
+    }
+
+    private String getUserIdFromSecurityContext() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            Object principal = authentication.getPrincipal();
+            if (principal instanceof UserDetails) {
+                return ((UserDetails) principal).getUsername();
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #335 

## 📌 작업 내용 및 특이사항
- 디바운싱 로직을 변경하였습니다.
- 기존 로직은 유저별 api 디바운싱이 아니라 GET을 제외한 모든 API가 다른 유저가 호출했을 때 1초동안 디바운싱 되던 문제가 있었습니다.
- userId를 SecurityContextHolder에서 추출하고 userId와 requestId를 조합하여 `ConcurrentSkipListSet`에서 관리하는 방식으로 변경하여 한 명의 유저가 자신이 요청한 자원 생성 API에 대한 디바운싱만 적용되도록 하였습니다.
- `팔로우/팔로잉 생성`같은 경우 하나의 유저가 팔로우 리스트에서 여러번 빠르게 누르는 경우도 있다고 합니다. 그래서 해당 API에 대한 userId + requestId 에 더해 대상 id를 추가하여 Request Body 파라미터에 따라 디바운싱이 되도록 구현하였습니다.

## 📝 참고사항
-