### PR TITLE
refactor: 팔로잉 여부 조회 API 스펙 변경

### DIFF
--- a/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/in/FollowUseCase.java
@@ -21,5 +21,5 @@ public interface FollowUseCase {
 
     void deleteByMemberId(Long memberId);
 
-    List<FollowCheck> isFollowing(Long memberId, List<Long> targetMemberId);
+    List<FollowCheck> checkFollowingState(Long memberId, List<Long> targetIds);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
@@ -28,5 +28,5 @@ public interface FriendPersistencePort {
 
     void deleteByMemberId(Long memberId);
 
-    List<FollowCheck> findByMemberIdAndFollowingIds(Long memberId, List<Long> targetMemberId);
+    List<FollowCheck> findByMemberIdAndFollowingIds(Long memberId, List<Long> targetIds);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
+++ b/module-domain/src/main/java/com/depromeet/friend/service/FollowService.java
@@ -73,7 +73,7 @@ public class FollowService implements FollowUseCase {
     }
 
     @Override
-    public List<FollowCheck> isFollowing(Long memberId, List<Long> targetMemberId) {
-        return friendPersistencePort.findByMemberIdAndFollowingIds(memberId, targetMemberId);
+    public List<FollowCheck> checkFollowingState(Long memberId, List<Long> targetIds) {
+        return friendPersistencePort.findByMemberIdAndFollowingIds(memberId, targetIds);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
@@ -3,7 +3,6 @@ package com.depromeet.member.port.in.usecase;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
-import java.util.List;
 
 public interface MemberUseCase {
     Member findById(Long id);
@@ -17,6 +16,4 @@ public interface MemberUseCase {
     Member findByProviderId(String providerId);
 
     Member createMemberBy(SocialMemberCommand command);
-
-    void checkByIdExist(List<Long> friends);
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
@@ -4,7 +4,6 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
-import java.util.List;
 import java.util.Optional;
 
 public interface MemberPersistencePort {
@@ -31,6 +30,4 @@ public interface MemberPersistencePort {
     Optional<Member> update(UpdateMemberCommand command);
 
     Optional<Member> updateProfileImageUrl(Long memberId, String profileImageUrl);
-
-    Boolean checkByIdExist(List<Long> friends);
 }

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -15,7 +15,6 @@ import com.depromeet.member.port.in.usecase.MemberUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import com.depromeet.type.member.MemberErrorType;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -81,13 +80,6 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUp
                         .profileImageUrl(command.defaultProfile())
                         .build();
         return memberPersistencePort.save(member);
-    }
-
-    @Override
-    public void checkByIdExist(List<Long> friends) {
-        if (!memberPersistencePort.checkByIdExist(friends)) {
-            throw new BadRequestException(MemberErrorType.NOT_FOUND_FROM_ID_LIST);
-        }
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemberRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemberRepository.java
@@ -122,15 +122,4 @@ public class FakeMemberRepository implements MemberPersistencePort {
                             return member;
                         });
     }
-
-    @Override
-    public Boolean checkByIdExist(List<Long> friends) {
-        List<Long> idList = data.stream().map(Member::getId).toList();
-        for (Long id : friends) {
-            if (!idList.contains(id)) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
@@ -217,8 +217,7 @@ public class FriendRepository implements FriendPersistencePort {
     }
 
     @Override
-    public List<FollowCheck> findByMemberIdAndFollowingIds(
-            Long memberId, List<Long> targetMemberId) {
+    public List<FollowCheck> findByMemberIdAndFollowingIds(Long memberId, List<Long> targetIds) {
         JPAQuery<Tuple> result =
                 queryFactory
                         .select(
@@ -229,7 +228,7 @@ public class FriendRepository implements FriendPersistencePort {
                                                 .from(friend)
                                                 .where(friend.member.id.eq(memberId))))
                         .from(member)
-                        .where(member.id.in(targetMemberId));
+                        .where(member.id.in(targetIds));
         return result.stream()
                 .map(res -> new FollowCheck(res.get(0, Long.class), res.get(1, Boolean.class)))
                 .toList();

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
@@ -1,7 +1,5 @@
 package com.depromeet.member.repository;
 
-import static com.querydsl.core.types.ExpressionUtils.count;
-
 import com.depromeet.friend.entity.QFriendEntity;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
@@ -150,17 +148,6 @@ public class MemberRepository implements MemberPersistencePort {
         return memberJpaRepository
                 .findById(memberId)
                 .map(memberEntity -> memberEntity.updateProfileImageUrl(profileImageUrl).toModel());
-    }
-
-    @Override
-    public Boolean checkByIdExist(List<Long> friends) {
-        Long resultSize =
-                queryFactory
-                        .select(count(member.id))
-                        .from(member)
-                        .where(member.id.in(friends))
-                        .fetchOne();
-        return resultSize != null && resultSize.intValue() == friends.size();
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
@@ -1,13 +1,13 @@
 package com.depromeet.friend.api;
 
 import com.depromeet.dto.response.ApiResponse;
-import com.depromeet.friend.dto.request.FollowCheckListRequest;
 import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.friend.dto.response.*;
 import com.depromeet.member.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,6 +34,9 @@ public interface FollowApi {
     ApiResponse<FollowingSummaryResponse> findFollowingSummary(@LoginMember Long memberId);
 
     @Operation(summary = "팔로잉 여부 조회")
-    ApiResponse<IsFollowingResponse> checkFollowing(
-            @LoginMember Long memberId, @RequestBody FollowCheckListRequest targetMemberId);
+    ApiResponse<FollowingStateResponse> checkFollowingState(
+            @LoginMember Long memberId,
+            @Parameter(description = "팔로잉 여부를 조회할 대상들의 PK 리스트", example = "1,2,3,4,5")
+                    @RequestParam("ids")
+                    List<Long> ids);
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
@@ -2,12 +2,12 @@ package com.depromeet.friend.api;
 
 import com.depromeet.config.Logging;
 import com.depromeet.dto.response.ApiResponse;
-import com.depromeet.friend.dto.request.FollowCheckListRequest;
 import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.friend.dto.response.*;
 import com.depromeet.friend.facade.FollowFacade;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.type.friend.FollowSuccessType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -56,11 +56,11 @@ public class FollowController implements FollowApi {
         return ApiResponse.success(FollowSuccessType.GET_FOLLOWING_SUMMARY_SUCCESS, response);
     }
 
-    @PostMapping
+    @GetMapping
     @Logging(item = "Follower/Following", action = "GET")
-    public ApiResponse<IsFollowingResponse> checkFollowing(
-            @LoginMember Long memberId, @RequestBody FollowCheckListRequest targetMemberId) {
-        IsFollowingResponse response = followFacade.isFollowing(memberId, targetMemberId);
+    public ApiResponse<FollowingStateResponse> checkFollowingState(
+            @LoginMember Long memberId, @RequestParam("ids") List<Long> ids) {
+        FollowingStateResponse response = followFacade.checkFollowingState(memberId, ids);
         return ApiResponse.success(FollowSuccessType.CHECK_FOLLOWING_SUCCESS, response);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingStateResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingStateResponse.java
@@ -6,14 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
-public record IsFollowingResponse(
+public record FollowingStateResponse(
         @NotNull
                 @Schema(
                         description = "팔로잉 여부",
                         example = "[true, false, true]",
                         requiredMode = Schema.RequiredMode.REQUIRED)
                 List<FollowCheckResponse> followingList) {
-    public static IsFollowingResponse toIsFollowingResponse(List<FollowCheck> isFollowing) {
-        return new IsFollowingResponse(isFollowing.stream().map(FollowCheckResponse::of).toList());
+    public static FollowingStateResponse toIsFollowingResponse(List<FollowCheck> followCheckVos) {
+        return new FollowingStateResponse(
+                followCheckVos.stream().map(FollowCheckResponse::of).toList());
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -4,7 +4,6 @@ import com.depromeet.friend.domain.vo.FollowCheck;
 import com.depromeet.friend.domain.vo.FollowSlice;
 import com.depromeet.friend.domain.vo.Follower;
 import com.depromeet.friend.domain.vo.Following;
-import com.depromeet.friend.dto.request.FollowCheckListRequest;
 import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.friend.dto.response.*;
 import com.depromeet.friend.port.in.FollowUseCase;
@@ -58,11 +57,9 @@ public class FollowFacade {
                 followingCount, followings, profileImageOrigin);
     }
 
-    @Transactional
-    public IsFollowingResponse isFollowing(Long memberId, FollowCheckListRequest targetMemberId) {
-        memberUseCase.checkByIdExist(targetMemberId.friends());
-        List<FollowCheck> isFollowing =
-                followUseCase.isFollowing(memberId, targetMemberId.friends());
-        return IsFollowingResponse.toIsFollowingResponse(isFollowing);
+    @Transactional(readOnly = true)
+    public FollowingStateResponse checkFollowingState(Long memberId, List<Long> targetIds) {
+        List<FollowCheck> followCheckVos = followUseCase.checkFollowingState(memberId, targetIds);
+        return FollowingStateResponse.toIsFollowingResponse(followCheckVos);
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #342 

## 📌 작업 내용 및 특이사항
- 팔로잉 여부 조회 API를 `POST`에서 `GET` 메소드로 변경하였습니다.
- GET으로 변경됨에 따라 RequestBody 방식에서 `RequestParam의 ids`를 받도록 변경하였습니다.
- 팔로잉 여부 조회 API 메소드 내부 DTO 네이밍을 변경하였습니다.
- 팔로잉 여부 조회 API 시 요청 id 리스트에 들어 있는 id가 `유효한 멤버인지 검증하는 로직을 제거`하였습니다.
  - 이미 조회 시 `유효한 멤버들만 응답값에 포함`시키기 때문에 재검증, `비효율`이라고 생각해서 제거하였습니다.