### PR TITLE
refactor: 수영 기록 수정 API undefined 핸들링

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryDetailPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryDetailPersistencePort.java
@@ -10,4 +10,6 @@ public interface MemoryDetailPersistencePort {
     Optional<MemoryDetail> update(Long id, MemoryDetail updateMemoryDetail);
 
     void deleteAllById(List<Long> memoryDetailIds);
+
+    void deleteById(Long removeTargetId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -14,7 +14,7 @@ public interface MemoryPersistencePort {
 
     Optional<Memory> findByRecordAtAndMemberId(LocalDate recordAt, Long memberId);
 
-    Optional<Memory> update(Long memoryId, Memory memoryUpdate);
+    Optional<Memory> update(Long memoryId, Memory updateMemory);
 
     int findOrderInMonth(Long memberId, Long memoryId, int month);
 

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -160,6 +160,15 @@ public class MemoryService
     }
 
     private MemoryDetail updateMemoryDetail(UpdateMemoryCommand command, Memory memory) {
+        if (isEmptyMemoryDetail(command)) {
+            if (memory.getMemoryDetail() == null) {
+                return null;
+            }
+            Long removeTargetId = memory.getMemoryDetail().getId();
+            memoryDetailPersistencePort.deleteById(removeTargetId);
+            return null;
+        }
+
         MemoryDetail updateMemoryDetail =
                 MemoryDetail.builder()
                         .item(command.item())
@@ -178,6 +187,13 @@ public class MemoryService
             updateMemoryDetail = memoryDetailPersistencePort.save(updateMemoryDetail);
         }
         return updateMemoryDetail;
+    }
+
+    private boolean isEmptyMemoryDetail(UpdateMemoryCommand command) {
+        return command.item() == null
+                && command.heartRate() == null
+                && command.pace() == null
+                && command.kcal() == null;
     }
 
     private Pool getUpdatePool(Long poolId, Pool pool) {

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemoryDetailRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemoryDetailRepository.java
@@ -64,4 +64,9 @@ public class FakeMemoryDetailRepository implements MemoryDetailPersistencePort {
     public void deleteAllById(List<Long> memoryDetailIds) {
         data.removeIf(item -> memoryDetailIds.contains(item.getId()));
     }
+
+    @Override
+    public void deleteById(Long removeTargetId) {
+        data.removeIf(item -> item.getId().equals(removeTargetId));
+    }
 }

--- a/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/FakeMemoryRepository.java
@@ -52,7 +52,7 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public Optional<Memory> update(Long memoryId, Memory memoryUpdate) {
+    public Optional<Memory> update(Long memoryId, Memory updateMemory) {
         Optional<Memory> md = data.stream().filter(item -> item.getId().equals(memoryId)).findAny();
         if (md.isEmpty()) {
             return Optional.empty();
@@ -63,40 +63,40 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
                             .id(memoryId)
                             .member(origin.getMember())
                             .pool(
-                                    memoryUpdate.getPool() != null
-                                            ? memoryUpdate.getPool()
+                                    updateMemory.getPool() != null
+                                            ? updateMemory.getPool()
                                             : origin.getPool())
                             .memoryDetail(
-                                    memoryUpdate.getMemoryDetail() != null
-                                            ? memoryUpdate.getMemoryDetail()
+                                    updateMemory.getMemoryDetail() != null
+                                            ? updateMemory.getMemoryDetail()
                                             : origin.getMemoryDetail())
                             .strokes(
-                                    memoryUpdate.getStrokes() != null
-                                            ? memoryUpdate.getStrokes()
+                                    updateMemory.getStrokes() != null
+                                            ? updateMemory.getStrokes()
                                             : origin.getStrokes())
                             .images(
-                                    memoryUpdate.getImages() != null
-                                            ? memoryUpdate.getImages()
+                                    updateMemory.getImages() != null
+                                            ? updateMemory.getImages()
                                             : origin.getImages())
                             .recordAt(
-                                    memoryUpdate.getRecordAt() != null
-                                            ? memoryUpdate.getRecordAt()
+                                    updateMemory.getRecordAt() != null
+                                            ? updateMemory.getRecordAt()
                                             : origin.getRecordAt())
                             .startTime(
-                                    memoryUpdate.getStartTime() != null
-                                            ? memoryUpdate.getStartTime()
+                                    updateMemory.getStartTime() != null
+                                            ? updateMemory.getStartTime()
                                             : origin.getStartTime())
                             .endTime(
-                                    memoryUpdate.getEndTime() != null
-                                            ? memoryUpdate.getEndTime()
+                                    updateMemory.getEndTime() != null
+                                            ? updateMemory.getEndTime()
                                             : origin.getEndTime())
                             .lane(
-                                    memoryUpdate.getLane() != null
-                                            ? memoryUpdate.getLane()
+                                    updateMemory.getLane() != null
+                                            ? updateMemory.getLane()
                                             : origin.getLane())
                             .diary(
-                                    memoryUpdate.getDiary() != null
-                                            ? memoryUpdate.getDiary()
+                                    updateMemory.getDiary() != null
+                                            ? updateMemory.getDiary()
                                             : origin.getDiary())
                             .build());
         }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryDetailEntity.java
@@ -61,10 +61,10 @@ public class MemoryDetailEntity {
     }
 
     public MemoryDetailEntity update(MemoryDetailEntity mde) {
-        if (mde.getItem() != null) this.item = mde.getItem();
-        if (mde.getHeartRate() != null) this.heartRate = mde.getHeartRate();
-        if (mde.getPace() != null) this.pace = mde.getPace();
-        if (mde.getKcal() != null) this.kcal = mde.getKcal();
+        this.item = mde.getItem();
+        this.heartRate = mde.getHeartRate();
+        this.pace = mde.getPace();
+        this.kcal = mde.getKcal();
         return this;
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -1,7 +1,5 @@
 package com.depromeet.memory.entity;
 
-import static org.eclipse.jdt.internal.compiler.parser.Parser.*;
-
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.entity.ImageEntity;
 import com.depromeet.member.entity.MemberEntity;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -1,5 +1,7 @@
 package com.depromeet.memory.entity;
 
+import static org.eclipse.jdt.internal.compiler.parser.Parser.*;
+
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.entity.ImageEntity;
 import com.depromeet.member.entity.MemberEntity;
@@ -23,6 +25,9 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "memory_entity",
+        indexes = {@Index(name = "idx_memory_detail_id", columnList = "memory_detail_id")})
 public class MemoryEntity {
     @Id
     @Column(name = "memory_id")
@@ -39,7 +44,7 @@ public class MemoryEntity {
     private PoolEntity pool;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "memory_detail_id")
+    @JoinColumn(name = "memory_detail_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private MemoryDetailEntity memoryDetail;
 
     @OneToMany(mappedBy = "memory")
@@ -219,14 +224,14 @@ public class MemoryEntity {
 
     public MemoryEntity update(MemoryEntity me) {
         if (me.getPool() != null) this.pool = me.getPool();
-        if (me.getMemoryDetail() != null) this.memoryDetail = me.getMemoryDetail();
         if (me.getStrokes() != null) this.strokes = me.getStrokes();
         if (me.getImages() != null) this.images = me.getImages();
         if (me.getRecordAt() != null) this.recordAt = me.getRecordAt();
         if (me.getStartTime() != null) this.startTime = me.getStartTime();
         if (me.getEndTime() != null) this.endTime = me.getEndTime();
         if (me.getLane() != null) this.lane = me.getLane();
-        if (me.getDiary() != null) this.diary = me.getDiary();
+        this.memoryDetail = me.getMemoryDetail();
+        this.diary = me.getDiary();
         return this;
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryDetailRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryDetailRepository.java
@@ -32,4 +32,9 @@ public class MemoryDetailRepository implements MemoryDetailPersistencePort {
     public void deleteAllById(List<Long> memoryDetailIds) {
         memoryDetailJpaRepository.deleteAllById(memoryDetailIds);
     }
+
+    @Override
+    public void deleteById(Long removeTargetId) {
+        memoryDetailJpaRepository.deleteById(removeTargetId);
+    }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -88,10 +88,10 @@ public class MemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public Optional<Memory> update(Long memoryId, Memory memoryUpdate) {
+    public Optional<Memory> update(Long memoryId, Memory updateMemory) {
         return memoryJpaRepository
                 .findById(memoryId)
-                .map(entity -> entity.update(MemoryEntity.from(memoryUpdate)).toModel());
+                .map(entity -> entity.update(MemoryEntity.from(updateMemory)).toModel());
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -50,8 +50,8 @@ public class MemoryController implements MemoryApi {
     public ApiResponse<MemoryResponse> update(
             @LoginMember Long memberId,
             @PathVariable("memoryId") Long memoryId,
-            @Valid @RequestBody MemoryUpdateRequest memoryUpdateRequest) {
-        MemoryResponse response = memoryFacade.update(memberId, memoryId, memoryUpdateRequest);
+            @Valid @RequestBody MemoryUpdateRequest request) {
+        MemoryResponse response = memoryFacade.update(memberId, memoryId, request);
         return ApiResponse.success(MemorySuccessType.PATCH_RESULT_SUCCESS, response);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryCreateRequest.java
@@ -30,11 +30,11 @@ public class MemoryCreateRequest {
 
     @Min(0)
     @Schema(description = "페이스 분", example = "5", maxLength = 3, type = "int")
-    private int paceMinutes;
+    private Integer paceMinutes;
 
     @Min(0)
     @Schema(description = "페이스 초", example = "30", maxLength = 2, type = "int")
-    private int paceSeconds;
+    private Integer paceSeconds;
 
     @Min(0)
     @Schema(description = "칼로리", example = "300")

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/request/MemoryUpdateRequest.java
@@ -24,19 +24,15 @@ public class MemoryUpdateRequest {
     @Schema(description = "수영 장비", example = "오리발")
     private String item;
 
-    @Min(0)
     @Schema(description = "심박수", example = "129")
     private Short heartRate;
 
-    @Min(0)
     @Schema(description = "페이스 분", example = "5", maxLength = 2, type = "int")
-    private int paceMinutes;
+    private Integer paceMinutes;
 
-    @Min(0)
     @Schema(description = "페이스 초", example = "30", maxLength = 2, type = "int")
-    private int paceSeconds;
+    private Integer paceSeconds;
 
-    @Min(0)
     @Schema(description = "칼로리", example = "300")
     private Integer kcal;
 
@@ -72,8 +68,8 @@ public class MemoryUpdateRequest {
             Long poolId,
             String item,
             Short heartRate,
-            int paceMinutes,
-            int paceSeconds,
+            Integer paceMinutes,
+            Integer paceSeconds,
             Integer kcal,
             LocalDate recordAt,
             LocalTime startTime,

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryDetailResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MemoryDetailResponse(
-        String item, Short heartRate, int paceMinutes, int paceSeconds, Integer kcal) {
+        String item, Short heartRate, Integer paceMinutes, Integer paceSeconds, Integer kcal) {
     @Builder
     public MemoryDetailResponse {}
 
@@ -14,9 +14,17 @@ public record MemoryDetailResponse(
         return MemoryDetailResponse.builder()
                 .item(memoryDetail.getItem())
                 .heartRate(memoryDetail.getHeartRate())
-                .paceMinutes(memoryDetail.getPace().getMinute())
-                .paceSeconds(memoryDetail.getPace().getSecond())
+                .paceMinutes(getMinute(memoryDetail))
+                .paceSeconds(getSecond(memoryDetail))
                 .kcal(memoryDetail.getKcal())
                 .build();
+    }
+
+    private static Integer getSecond(MemoryDetail memoryDetail) {
+        return memoryDetail.getPace() != null ? memoryDetail.getPace().getSecond() : null;
+    }
+
+    private static Integer getMinute(MemoryDetail memoryDetail) {
+        return memoryDetail.getPace() != null ? memoryDetail.getPace().getMinute() : null;
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
@@ -49,7 +49,7 @@ public class MemoryMapper {
     }
 
     public static UpdateMemoryCommand toCommand(MemoryUpdateRequest request) {
-        LocalTime pace = LocalTime.of(0, request.getPaceMinutes(), request.getPaceSeconds());
+        LocalTime pace = getPace(request);
         return UpdateMemoryCommand.builder()
                 .poolId(request.getPoolId())
                 .item(request.getItem())
@@ -68,6 +68,15 @@ public class MemoryMapper {
                                         .toList()
                                 : null)
                 .build();
+    }
+
+    private static LocalTime getPace(MemoryUpdateRequest request) {
+        if (request.getPaceMinutes() != null || request.getPaceSeconds() != null) {
+            int minute = request.getPaceMinutes() != null ? request.getPaceMinutes() : 0;
+            int second = request.getPaceSeconds() != null ? request.getPaceSeconds() : 0;
+            return LocalTime.of(0, minute, second);
+        }
+        return null;
     }
 
     public static TimelineSliceResponse toSliceResponse(


### PR DESCRIPTION
## 🌱 관련 이슈

- close #345 

## 📌 작업 내용 및 특이사항
- 수영 기록 수정 시 MemoryDetail 관련 필드, diary 필드가 undefined 즉, 요청 바디에 포함이 되지 않았을 때 이를 아예 `필드에서 삭제하도록 구현`하였습니다.
- MemoryDetail 전체가 삭제될수도 있으므로 `외래키 제약 조건`은 없어져야 합니다. 외래키 제약 조건을 없앰에 따라 `외래키에 대한 인덱스`를 추가적으로 설정해주었습니다.

## 📝 참고사항
`[수영 기록 생성]`
<img width="842" alt="스크린샷 2024-08-31 오전 2 02 08" src="https://github.com/user-attachments/assets/64ad02e7-08f9-4605-88cc-92f60feae9c8">

`[kcal 필드를 제외하고 모두 삭제하여 요청했을 때]`
<img width="291" alt="스크린샷 2024-08-31 오전 2 03 05" src="https://github.com/user-attachments/assets/aeb02945-d18d-47a4-a506-53c5c4c31408">
<img width="348" alt="스크린샷 2024-08-31 오전 2 02 58" src="https://github.com/user-attachments/assets/5769bf9e-bcc2-4b39-8323-e02101f0844f">

`[다양한 다른 예시]`
<img width="244" alt="스크린샷 2024-08-31 오전 2 03 32" src="https://github.com/user-attachments/assets/004c5436-7d82-4df2-a1ea-5699c69fb1ba">
<img width="177" alt="스크린샷 2024-08-31 오전 2 03 15" src="https://github.com/user-attachments/assets/d3f6ff0f-4b10-4782-8273-274939c142e6">



