### PR TITLE
refactor: ReactionLog 복합 인덱스를 이용한 API 성능 개선

### DIFF
--- a/module-domain/src/main/java/com/depromeet/notification/domain/ReactionLog.java
+++ b/module-domain/src/main/java/com/depromeet/notification/domain/ReactionLog.java
@@ -1,5 +1,6 @@
 package com.depromeet.notification.domain;
 
+import com.depromeet.member.domain.Member;
 import com.depromeet.reaction.domain.Reaction;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -8,13 +9,16 @@ import lombok.Getter;
 @Getter
 public class ReactionLog {
     private Long id;
+    private Member receiver;
     private Reaction reaction;
     private LocalDateTime createdAt;
     private boolean hasRead;
 
     @Builder
-    public ReactionLog(Long id, Reaction reaction, LocalDateTime createdAt, boolean hasRead) {
+    public ReactionLog(
+            Long id, Member receiver, Reaction reaction, LocalDateTime createdAt, boolean hasRead) {
         this.id = id;
+        this.receiver = receiver;
         this.reaction = reaction;
         this.createdAt = createdAt;
         this.hasRead = hasRead;

--- a/module-domain/src/main/java/com/depromeet/notification/event/ReactionLogEvent.java
+++ b/module-domain/src/main/java/com/depromeet/notification/event/ReactionLogEvent.java
@@ -1,9 +1,10 @@
 package com.depromeet.notification.event;
 
+import com.depromeet.member.domain.Member;
 import com.depromeet.reaction.domain.Reaction;
 
-public record ReactionLogEvent(Reaction reaction) {
-    public static ReactionLogEvent from(Reaction reaction) {
-        return new ReactionLogEvent(reaction);
+public record ReactionLogEvent(Member receiver, Reaction reaction) {
+    public static ReactionLogEvent of(Member receiver, Reaction reaction) {
+        return new ReactionLogEvent(receiver, reaction);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/notification/service/ReactionLogService.java
+++ b/module-domain/src/main/java/com/depromeet/notification/service/ReactionLogService.java
@@ -26,7 +26,11 @@ public class ReactionLogService
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void save(ReactionLogEvent event) {
         ReactionLog reactionLog =
-                ReactionLog.builder().reaction(event.reaction()).hasRead(false).build();
+                ReactionLog.builder()
+                        .receiver(event.receiver())
+                        .reaction(event.reaction())
+                        .hasRead(false)
+                        .build();
         reactionLogPersistencePort.save(reactionLog);
     }
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/entity/ReactionLogEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/entity/ReactionLogEntity.java
@@ -1,6 +1,8 @@
 package com.depromeet.notification.entity;
 
 import com.depromeet.basetime.BaseTimeEntity;
+import com.depromeet.member.domain.Member;
+import com.depromeet.member.entity.MemberEntity;
 import com.depromeet.notification.domain.ReactionLog;
 import com.depromeet.reaction.entity.ReactionEntity;
 import jakarta.persistence.Column;
@@ -25,6 +27,10 @@ public class ReactionLogEntity extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @JoinColumn(name = "receiver_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private MemberEntity receiver;
+
     @JoinColumn(name = "reaction_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private ReactionEntity reaction;
@@ -32,8 +38,10 @@ public class ReactionLogEntity extends BaseTimeEntity {
     private boolean hasRead;
 
     @Builder
-    public ReactionLogEntity(Long id, ReactionEntity reaction, boolean hasRead) {
+    public ReactionLogEntity(
+            Long id, MemberEntity receiver, ReactionEntity reaction, boolean hasRead) {
         this.id = id;
+        this.receiver = receiver;
         this.reaction = reaction;
         this.hasRead = hasRead;
     }
@@ -56,8 +64,9 @@ public class ReactionLogEntity extends BaseTimeEntity {
                 .build();
     }
 
-    public static ReactionLogEntity from(ReactionLog reactionLog) {
+    public static ReactionLogEntity of(Member receiver, ReactionLog reactionLog) {
         return ReactionLogEntity.builder()
+                .receiver(MemberEntity.from(receiver))
                 .reaction(ReactionEntity.from(reactionLog.getReaction()))
                 .hasRead(reactionLog.isHasRead())
                 .build();

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/ReactionLogRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/ReactionLogRepository.java
@@ -28,7 +28,9 @@ public class ReactionLogRepository implements ReactionLogPersistencePort {
 
     @Override
     public ReactionLog save(ReactionLog reactionLog) {
-        return reactionLogJpaRepository.save(ReactionLogEntity.from(reactionLog)).toPureModel();
+        return reactionLogJpaRepository
+                .save(ReactionLogEntity.of(reactionLog.getReceiver(), reactionLog))
+                .toPureModel();
     }
 
     @Override
@@ -41,8 +43,6 @@ public class ReactionLogRepository implements ReactionLogPersistencePort {
                 .join(reactionEntity.member, member)
                 .fetchJoin()
                 .join(reactionEntity.memory, memoryEntity)
-                .fetchJoin()
-                .join(memoryEntity.member, memoryMember)
                 .fetchJoin()
                 .where(memberEq(memberId), createdAtLoe(cursorCreatedAt))
                 .limit(11)
@@ -67,7 +67,6 @@ public class ReactionLogRepository implements ReactionLogPersistencePort {
                 .join(reactionLogEntity.reaction, reactionEntity)
                 .join(reactionEntity.member, member)
                 .join(reactionEntity.memory, memoryEntity)
-                .join(memoryEntity.member, memoryMember)
                 .where(memberEq(memberId), reactionLogEntity.hasRead.isFalse())
                 .fetchOne();
     }
@@ -93,8 +92,6 @@ public class ReactionLogRepository implements ReactionLogPersistencePort {
                 .fetchJoin()
                 .join(reactionEntity.memory, memoryEntity)
                 .fetchJoin()
-                .join(memoryEntity.member, memoryMember)
-                .fetchJoin()
                 .where(memberEq(memberId), reactionLogEq(reactionLogId))
                 .fetchOne();
     }
@@ -110,7 +107,7 @@ public class ReactionLogRepository implements ReactionLogPersistencePort {
         if (memberId == null) {
             return null;
         }
-        return memoryMember.id.eq(memberId);
+        return reactionLogEntity.receiver.id.eq(memberId);
     }
 
     private BooleanExpression reactionLogEq(Long reactionLogId) {

--- a/module-presentation/src/main/java/com/depromeet/reaction/facade/ReactionFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/facade/ReactionFacade.java
@@ -41,7 +41,7 @@ public class ReactionFacade {
         Memory memory = getMemoryUseCase.findByIdWithMember(request.memoryId());
         Reaction reaction =
                 createReactionUseCase.save(memberId, memory, ReactionMapper.toCommand(request));
-        eventPublisher.publishEvent(ReactionLogEvent.from(reaction));
+        eventPublisher.publishEvent(ReactionLogEvent.of(memory.getMember(), reaction));
     }
 
     public MemoryReactionResponse getReactionsOfMemory(Long memoryId) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #357 

## 📌 작업 내용 및 특이사항
- 알림 조회 API 수행시간 개선을 위해 SQL 실행 계획을 분석하였습니다.
- SQL문 분석 결과 FriendLogEntity 테이블의 쿼리는 PK 인덱스를 정상적으로 잘 탔지만, ReactionLogEntity 쿼리 실행 계획 분석 결과 풀 테이블 스캔이 발생함을 찾아냈습니다. (참고 사항 사진 참조해주세요!)
- `Using filesort`: 이 부분이 성능 문제를 야기할 수 있습니다. `filesort`는 MySQL이 인덱스를 사용하지 않고 디스크에 임시 파일을 만들어 정렬 작업을 수행하고 있음을 의미합니다. 이는 정렬 작업이 많아질수록 `성능 저하`를 초래할 수 있습니다. 따라서 이를 개선하기 위해 join 비용을 줄이고 `receiver_id`를 필드에 추가하였습니다.

- 순차적인 개선을 하였습니다.
- 먼저 기존 API를 테스트 한 사진을 첨부합니다. `[사진 - 참조1]`
- 먼저 receiver_id를 테이블 필드로 추가하여 join 비용을 줄였습니다. `[사진 - 참조2]`
- 인덱스를 적용하여 수행 시간을 줄였습니다. `[사진 - 참조3]`

### 배포 시 수행해야 할 것
1. 기존 ReactionLogEntity에 receiver_id 필드를 추가
2. receiver_id 필드에 ReactionLogEntity의 Reaction의 Memory의 Member의 id를 주입하는 스크립트 수행

```sql
ALTER TABLE reaction_log_entity ADD COLUMN receiver_id BIGINT;

UPDATE reaction_log_entity rle
JOIN reaction_entity r1 ON r1.reaction_id = rle.reaction_id
JOIN memory_entity m ON m.memory_id = r1.memory_id
JOIN member_entity m2 ON m2.member_id = m.member_id
SET rle.receiver_id = m2.member_id
WHERE rle.receiver_id IS NULL;

CREATE INDEX idx_receiver_created_at ON reaction_log_entity (receiver_id, created_at);
```

## 📝 참고사항
`[ReactionLogEntity Using filesort 발생]`
<img width="1717" alt="image" src="https://github.com/user-attachments/assets/52f9c6e9-2aeb-4579-918d-036b9025b020">

[참조1 - 기존 API 수행시간 (조회 1000건 수행 - 평균 `23ms`)]
<img width="1035" alt="스크린샷 2024-09-03 오후 5 20 21" src="https://github.com/user-attachments/assets/a9b19a7b-213e-4da2-80d8-bc6d23491d5e">


[참조2 - receiver_id 필드 추가 (조회 1000건 수행 - 평균 `13ms` / `기존 대비 1.76배 개선`)]
![image](https://github.com/user-attachments/assets/84fb3352-fc9c-4ba7-b921-2fc2aeea34d2)

[참조3 - (receiver_id, created_at) 복합 인덱스 추가 (조회 1000건 수행 - 평균 `6ms` / 기존 대비 `3.83배 개선`)]
![image](https://github.com/user-attachments/assets/0588ec1a-4c09-4eba-8509-755dfb81c6d1)

---

`하지만 1000건 조회이기 때문에 JVM warmup에 따른 편차가 존재할 수 있어 10만건 단위로 조회해보았습니다.`
`[기존 방식]`
<img width="1017" alt="스크린샷 2024-09-03 오후 5 48 39" src="https://github.com/user-attachments/assets/1ea1e836-7103-4c30-9890-b0f7aa8ec222">

`[receiver_id 필드 추가]`
<img width="1027" alt="스크린샷 2024-09-03 오후 5 43 36" src="https://github.com/user-attachments/assets/e502836c-8a0d-4694-b440-2843fecd113c">

`[복합 인덱스 추가]`
<img width="1017" alt="스크린샷 2024-09-03 오후 5 45 14" src="https://github.com/user-attachments/assets/2967fdf4-cdf9-4efe-8659-214bc919fc60">

해당 결과에서 주의해야 할 건 최대값은 복합 인덱스 추가에서 가장 많이 나왔지만 해당 결과는 outlier이기 때문에 무시해주시면 됩니다. 중요하게 보아야 할 것은 `처리량, 수신 KB, 전송 KB` 입니다. 개선할수록 해당 값이 높게 나와 성능이 향상된 것을 볼 수 있습니다. 로컬호스트에서는 데이터가 많지 않아 해당 차이가 적지만, 운영을 하면 할수록 해당 API 성능 격차는 점점 커질 것으로 예상됩니다.

---

`복합 인덱스`의 효과를 확인하기 위해 cursorCreatedAt 파라미터를 넣고 수행해보았습니다.
[기존 API (조회 1000건 수행 / 평균 `9ms`]
![image](https://github.com/user-attachments/assets/5cb1afc4-63ac-48ca-a333-5384e5201817)

[개선된 API (조회 1000건 수행 / 평균 `6ms`]
<img width="1021" alt="스크린샷 2024-09-03 오후 6 19 22" src="https://github.com/user-attachments/assets/4c1ce424-3645-4748-84c5-903886c9901e">
