### PR TITLE
fix: 성별 선택 안 함 추가

### DIFF
--- a/module-domain/src/main/java/com/depromeet/member/domain/MemberGender.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/MemberGender.java
@@ -5,7 +5,8 @@ import com.depromeet.converter.CodedEnum;
 
 public enum MemberGender implements CodedEnum<String> {
     M("M"),
-    W("W");
+    W("W"),
+    N("N");
 
     private final String value;
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -72,7 +72,7 @@ public class MemberEntity {
     @PrePersist
     public void prePersist() {
         this.goal = 1000;
-        this.gender = MemberGender.M;
+        this.gender = MemberGender.W;
     }
 
     public static MemberEntity from(Member member) {

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -60,9 +60,14 @@ public class MemberFacade {
     }
 
     public Member updateGender(Long memberId, String gender) {
-        MemberGender newGender =
-                gender.equals(MemberGender.M.getValue()) ? MemberGender.M : MemberGender.W;
+        MemberGender newGender = getGender(gender);
         return memberUpdateUseCase.updateGender(memberId, newGender);
+    }
+
+    private static MemberGender getGender(String gender) {
+        return gender.equals(MemberGender.M.getValue())
+                ? MemberGender.M
+                : gender.equals(MemberGender.W.getValue()) ? MemberGender.W : MemberGender.N;
     }
 
     public MemberSearchResponse searchByName(Long memberId, String nameQuery, Long cursorId) {

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -60,14 +60,8 @@ public class MemberFacade {
     }
 
     public Member updateGender(Long memberId, String gender) {
-        MemberGender newGender = getGender(gender);
+        MemberGender newGender = MemberGender.valueOf(gender);
         return memberUpdateUseCase.updateGender(memberId, newGender);
-    }
-
-    private static MemberGender getGender(String gender) {
-        return gender.equals(MemberGender.M.getValue())
-                ? MemberGender.M
-                : gender.equals(MemberGender.W.getValue()) ? MemberGender.W : MemberGender.N;
     }
 
     public MemberSearchResponse searchByName(Long memberId, String nameQuery, Long cursorId) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #360

## 📌 작업 내용 및 특이사항
- 애플 스토어 앱 심사를 위해 성별을 남, 녀 뿐만 아니라 선택 안 함 필드를 추가합니다.
- M, W, N으로 수정합니다.
- 여성 이용자들이 더 많을 것으로 예상된다는 기획에 따라 가입 시 성별 기본 값을 W(여성)로 수정합니다.

## 📝 참고사항
- 성별 수정 성공
<img width="512" alt="Screenshot 2024-09-04 at 20 55 00" src="https://github.com/user-attachments/assets/30a96f26-9f92-4f96-99be-4af49c65dbdf">
<img width="846" alt="Screenshot 2024-09-04 at 20 55 08" src="https://github.com/user-attachments/assets/29ea5db5-014e-454d-9356-51cfba58275c">
<img width="511" alt="Screenshot 2024-09-04 at 20 55 16" src="https://github.com/user-attachments/assets/be812d23-3aa6-485b-aeee-587cba3fb613">

- 성별 입력 값 검증
<img width="861" alt="Screenshot 2024-09-04 at 20 55 31" src="https://github.com/user-attachments/assets/a663028c-4a76-4b23-84fa-3d10e910d55f">