### PR TITLE
fix: 회원 탈퇴 시 Memory Detail 이 없는 경우 에러 수정

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/domain/vo/MemoryAndDetailId.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/vo/MemoryAndDetailId.java
@@ -1,0 +1,5 @@
+package com.depromeet.memory.domain.vo;
+
+import java.util.List;
+
+public record MemoryAndDetailId(List<Long> memoryIds, List<Long> memoryDetailIds) {}

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
@@ -1,6 +1,7 @@
 package com.depromeet.memory.port.in.usecase;
 
 import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.domain.vo.MemoryAndDetailId;
 import com.depromeet.memory.domain.vo.MemoryInfo;
 import java.util.List;
 
@@ -14,4 +15,6 @@ public interface GetMemoryUseCase {
     List<Memory> findByMemberId(Long memberId);
 
     MemoryInfo findByIdWithPrevNext(Long requestMemberId, Long memoryId);
+
+    MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -1,6 +1,7 @@
 package com.depromeet.memory.port.out.persistence;
 
 import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.domain.vo.MemoryAndDetailId;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -35,4 +36,6 @@ public interface MemoryPersistencePort {
     void setNullByIds(List<Long> memoryIds);
 
     void deleteAllByMemberId(Long memberId);
+
+    MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -9,6 +9,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.domain.Stroke;
+import com.depromeet.memory.domain.vo.MemoryAndDetailId;
 import com.depromeet.memory.domain.vo.MemoryInfo;
 import com.depromeet.memory.port.in.command.CreateMemoryCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
@@ -102,6 +103,11 @@ public class MemoryService
                         memory.getRecordAt(), memory.getMember().getId());
         Boolean isMyMemory = isMyMemory(memory.getMember().getId(), requestMemberId);
         return new MemoryInfo(memory, prevId, nextId, isMyMemory);
+    }
+
+    @Override
+    public MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId) {
+        return memoryPersistencePort.findMemoryAndDetailIdsByMemberId(memberId);
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
@@ -1,6 +1,7 @@
 package com.depromeet.mock.memory;
 
 import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.domain.vo.MemoryAndDetailId;
 import com.depromeet.memory.port.out.persistence.MemoryPersistencePort;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -209,5 +210,15 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     @Override
     public void deleteAllByMemberId(Long memberId) {
         data.removeIf(item -> item.getMember().getId().equals(memberId));
+    }
+
+    @Override
+    public MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId) {
+        List<Memory> memories =
+                data.stream().filter(item -> item.getMember().getId().equals(memberId)).toList();
+        List<Long> memoryIds = memories.stream().map(Memory::getId).toList();
+        List<Long> memoryDetailIds =
+                memories.stream().map(item -> item.getMemoryDetail().getId()).toList();
+        return new MemoryAndDetailId(memoryIds, memoryDetailIds);
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryDetailRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryDetailRepository.java
@@ -2,7 +2,9 @@ package com.depromeet.memory.repository;
 
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.entity.MemoryDetailEntity;
+import com.depromeet.memory.entity.QMemoryDetailEntity;
 import com.depromeet.memory.port.out.persistence.MemoryDetailPersistencePort;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +13,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class MemoryDetailRepository implements MemoryDetailPersistencePort {
+    private final JPAQueryFactory queryFactory;
     private final MemoryDetailJpaRepository memoryDetailJpaRepository;
+
+    private QMemoryDetailEntity memoryDetail = QMemoryDetailEntity.memoryDetailEntity;
 
     @Override
     public MemoryDetail save(MemoryDetail memoryDetail) {
@@ -30,7 +35,7 @@ public class MemoryDetailRepository implements MemoryDetailPersistencePort {
 
     @Override
     public void deleteAllById(List<Long> memoryDetailIds) {
-        memoryDetailJpaRepository.deleteAllById(memoryDetailIds);
+        queryFactory.delete(memoryDetail).where(memoryDetail.id.in(memoryDetailIds)).execute();
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -7,9 +7,11 @@ import static com.depromeet.memory.entity.QStrokeEntity.strokeEntity;
 import static com.depromeet.pool.entity.QPoolEntity.poolEntity;
 
 import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.domain.vo.MemoryAndDetailId;
 import com.depromeet.memory.entity.MemoryEntity;
 import com.depromeet.memory.entity.QMemoryEntity;
 import com.depromeet.memory.port.out.persistence.MemoryPersistencePort;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
@@ -220,6 +222,21 @@ public class MemoryRepository implements MemoryPersistencePort {
     @Override
     public void deleteAllByMemberId(Long memberId) {
         queryFactory.delete(memory).where(memberEq(memberId)).execute();
+    }
+
+    @Override
+    public MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId) {
+        List<Tuple> result =
+                queryFactory
+                        .select(memory.id, memory.memoryDetail.id)
+                        .from(memory)
+                        .leftJoin(memory.memoryDetail, memoryDetailEntity)
+                        .where(memberEq(memberId))
+                        .fetch();
+        List<Long> memoryIds = result.stream().map(r -> r.get(memory.id)).toList();
+        List<Long> memoryDetailIds =
+                result.stream().map(r -> r.get(memory.memoryDetail.id)).toList();
+        return new MemoryAndDetailId(memoryIds, memoryDetailIds);
     }
 
     private BooleanExpression loeRecordAt(LocalDate recordAt) {

--- a/module-infrastructure/persistence-database/src/test/java/com/depromeet/followinglog/repository/FollowingMemoryLogRepositoryTest.java
+++ b/module-infrastructure/persistence-database/src/test/java/com/depromeet/followinglog/repository/FollowingMemoryLogRepositoryTest.java
@@ -65,7 +65,8 @@ public class FollowingMemoryLogRepositoryTest {
         memberRepository = new MemberRepository(queryFactory, memberJpaRepository);
         friendRepository = new FriendRepository(queryFactory, friendJpaRepository);
         memoryRepository = new MemoryRepository(em, queryFactory, memoryJpaRepository);
-        memoryDetailRepository = new MemoryDetailRepository(memoryDetailJpaRepository);
+        memoryDetailRepository =
+                new MemoryDetailRepository(queryFactory, memoryDetailJpaRepository);
         followingMemoryLogRepository =
                 new FollowingMemoryLogRepository(queryFactory, followingMemoryLogJpaRepository);
 

--- a/module-infrastructure/persistence-database/src/test/java/com/depromeet/image/repository/ImageRepositoryTest.java
+++ b/module-infrastructure/persistence-database/src/test/java/com/depromeet/image/repository/ImageRepositoryTest.java
@@ -53,7 +53,8 @@ public class ImageRepositoryTest {
         imageRepository = new ImageRepository(em, queryFactory, imageJpaRepository);
         memberPersistencePort = new MemberRepository(queryFactory, memberJpaRepository);
         memoryPersistencePort = new MemoryRepository(em, queryFactory, memoryJpaRepository);
-        memoryDetailPersistencePort = new MemoryDetailRepository(memoryDetailJpaRepository);
+        memoryDetailPersistencePort =
+                new MemoryDetailRepository(queryFactory, memoryDetailJpaRepository);
         member = memberPersistencePort.save(MemberFixture.make());
     }
 

--- a/module-infrastructure/persistence-database/src/test/java/com/depromeet/memory/repository/MemoryRepositoryTest.java
+++ b/module-infrastructure/persistence-database/src/test/java/com/depromeet/memory/repository/MemoryRepositoryTest.java
@@ -45,7 +45,8 @@ public class MemoryRepositoryTest {
     void setUp() {
         memberRepository = new MemberRepository(queryFactory, memberJpaRepository);
         memoryRepository = new MemoryRepository(em, queryFactory, memoryJpaRepository);
-        memoryDetailRepository = new MemoryDetailRepository(memoryDetailJpaRepository);
+        memoryDetailRepository =
+                new MemoryDetailRepository(queryFactory, memoryDetailJpaRepository);
         member = memberRepository.save(MemberFixture.make());
         List<MemoryDetail> memoryDetailList = MemoryDetailFixture.makeMemoryDetails(30);
 

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -19,7 +19,7 @@ import com.depromeet.image.port.in.ImageUpdateUseCase;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.mapper.MemberMapper;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
-import com.depromeet.memory.domain.Memory;
+import com.depromeet.memory.domain.vo.MemoryAndDetailId;
 import com.depromeet.memory.port.in.usecase.DeleteMemoryUseCase;
 import com.depromeet.memory.port.in.usecase.GetMemoryUseCase;
 import com.depromeet.memory.port.in.usecase.StrokeUseCase;
@@ -119,10 +119,10 @@ public class AuthFacade {
         Member member = memberUseCase.findById(memberId);
         String accountType = member.getProviderId();
         // Memory 조회
-        List<Memory> memories = getMemoryUseCase.findByMemberId(memberId);
-        List<Long> memoryIds = memories.stream().map(Memory::getId).toList();
-        List<Long> memoryDetailIds =
-                memories.stream().map(memory -> memory.getMemoryDetail().getId()).toList();
+        MemoryAndDetailId memoryAndDetailId =
+                getMemoryUseCase.findMemoryAndDetailIdsByMemberId(memberId);
+        List<Long> memoryIds = memoryAndDetailId.memoryIds();
+        List<Long> memoryDetailIds = memoryAndDetailId.memoryDetailIds();
         // Following memory log 삭제
         followingMemoryLogUseCase.deleteAllByMemoryId(memoryIds);
         // Reaction 조회


### PR DESCRIPTION
## 🌱 관련 이슈

- close #363

## 📌 작업 내용 및 특이사항
- 회원 탈퇴 시 Memory Detail 이 없는 경우 NPE를 해결하였습니다.

## 📝 참고사항
- 로컬에서 웹 코드를 실행하여 탈퇴가 잘 진행되는 것을 확인하였습니다.
- 탈퇴 성공
<img width="583" alt="Screenshot 2024-09-05 at 12 57 55" src="https://github.com/user-attachments/assets/96d67dd3-b59c-4f9b-86c2-ca6678a5f891">
<img width="842" alt="Screenshot 2024-09-05 at 12 58 30" src="https://github.com/user-attachments/assets/2e901657-4245-4b9f-a755-9226685512a0">
