### PR TITLE
refactor: timeline api

### DIFF
--- a/module-domain/src/main/java/com/depromeet/image/domain/vo/MemoryImageUrlVo.java
+++ b/module-domain/src/main/java/com/depromeet/image/domain/vo/MemoryImageUrlVo.java
@@ -1,0 +1,3 @@
+package com.depromeet.image.domain.vo;
+
+public record MemoryImageUrlVo(Long memoryId, String imageName) {}

--- a/module-domain/src/main/java/com/depromeet/image/port/in/ImageGetUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/image/port/in/ImageGetUseCase.java
@@ -1,8 +1,11 @@
 package com.depromeet.image.port.in;
 
 import com.depromeet.image.domain.Image;
+import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import java.util.List;
 
 public interface ImageGetUseCase {
     List<Image> findImagesByMemoryId(Long memoryId);
+
+    List<MemoryImageUrlVo> findImagesByMemoryIds(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/image/port/out/persistence/ImagePersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/image/port/out/persistence/ImagePersistencePort.java
@@ -1,6 +1,7 @@
 package com.depromeet.image.port.out.persistence;
 
 import com.depromeet.image.domain.Image;
+import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,6 +11,8 @@ public interface ImagePersistencePort {
     List<Image> saveAll(List<Image> images);
 
     void updateByImageIds(List<Long> imageIds);
+
+    List<MemoryImageUrlVo> findByImageByMemoryIds(List<Long> memoryIds);
 
     Optional<Image> findById(Long id);
 

--- a/module-domain/src/main/java/com/depromeet/image/service/ImageGetService.java
+++ b/module-domain/src/main/java/com/depromeet/image/service/ImageGetService.java
@@ -1,6 +1,7 @@
 package com.depromeet.image.service;
 
 import com.depromeet.image.domain.Image;
+import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import com.depromeet.image.port.in.ImageGetUseCase;
 import com.depromeet.image.port.out.persistence.ImagePersistencePort;
 import java.util.List;
@@ -17,5 +18,10 @@ public class ImageGetService implements ImageGetUseCase {
     @Override
     public List<Image> findImagesByMemoryId(Long memoryId) {
         return imagePersistencePort.findAllByMemoryIdAndHasUploaded(memoryId);
+    }
+
+    @Override
+    public List<MemoryImageUrlVo> findImagesByMemoryIds(List<Long> memoryIds) {
+        return imagePersistencePort.findByImageByMemoryIds(memoryIds);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/Memory.java
@@ -3,7 +3,6 @@ package com.depromeet.memory.domain;
 import com.depromeet.image.domain.Image;
 import com.depromeet.member.domain.Member;
 import com.depromeet.pool.domain.Pool;
-import com.depromeet.reaction.domain.Reaction;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -19,7 +18,6 @@ public class Memory {
     private MemoryDetail memoryDetail;
     private List<Stroke> strokes;
     private List<Image> images;
-    private List<Reaction> reactions;
     private LocalDate recordAt;
     private LocalTime startTime;
     private LocalTime endTime;
@@ -34,7 +32,6 @@ public class Memory {
             MemoryDetail memoryDetail,
             List<Stroke> strokes,
             List<Image> images,
-            List<Reaction> reactions,
             LocalDate recordAt,
             LocalTime startTime,
             LocalTime endTime,
@@ -46,7 +43,6 @@ public class Memory {
         this.memoryDetail = memoryDetail;
         this.strokes = strokes;
         this.images = images;
-        this.reactions = reactions;
         this.recordAt = recordAt;
         this.startTime = startTime;
         this.endTime = endTime;

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/TimelineUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/TimelineUseCase.java
@@ -2,9 +2,7 @@ package com.depromeet.memory.port.in.usecase;
 
 import com.depromeet.memory.domain.vo.TimelineSlice;
 import java.time.LocalDate;
-import java.time.YearMonth;
 
 public interface TimelineUseCase {
-    TimelineSlice getTimelineByMemberIdAndCursorAndDate(
-            Long memberId, LocalDate cursorRecordAt, YearMonth date, boolean showNewer);
+    TimelineSlice getTimelineByMemberIdAndCursorAndDate(Long memberId, LocalDate cursorRecordAt);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -18,11 +18,7 @@ public interface MemoryPersistencePort {
 
     int findOrderInMonth(Long memberId, Long memoryId, int month);
 
-    List<Memory> findPrevMemoryByMemberId(
-            Long memberId, LocalDate cursorRecordAt, LocalDate recordAt);
-
-    List<Memory> findNextMemoryByMemberId(
-            Long memberId, LocalDate cursorRecordAt, LocalDate recordAt);
+    List<Memory> findPrevMemoryByMemberId(Long memberId, LocalDate cursorRecordAt);
 
     List<Memory> getCalendarByYearAndMonth(Long memberId, Integer year, Short month);
 

--- a/module-domain/src/main/java/com/depromeet/memory/service/TimelineService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/TimelineService.java
@@ -22,32 +22,18 @@ public class TimelineService implements TimelineUseCase {
 
     @Override
     public TimelineSlice getTimelineByMemberIdAndCursorAndDate(
-            Long memberId, LocalDate cursorRecordAt, YearMonth date, boolean showNewer) {
-        return getTimelines(memberId, cursorRecordAt, date, showNewer);
+            Long memberId, LocalDate cursorRecordAt) {
+        return getTimelines(memberId, cursorRecordAt);
     }
 
-    private TimelineSlice getTimelines(
-            Long memberId, LocalDate cursorRecordAt, YearMonth date, boolean showNewer) {
-        LocalDate parsedDate = getLocalDateOrNull(date); // date 파라미터 임시 제거로 인해 임시 null 처리
+    private TimelineSlice getTimelines(Long memberId, LocalDate cursorRecordAt) {
         boolean hasNext;
         LocalDate nextMemoryRecordAt;
         List<Memory> memories;
-        if (showNewer) {
-            memories =
-                    memoryPersistencePort.findNextMemoryByMemberId(
-                            memberId, cursorRecordAt, parsedDate);
-            hasNext = checkHasNext(memories);
-            nextMemoryRecordAt = getCursorRecordAt(memories);
-            memories = getMemories(memories);
-            memories = memories.reversed();
-        } else {
-            memories =
-                    memoryPersistencePort.findPrevMemoryByMemberId(
-                            memberId, cursorRecordAt, parsedDate);
-            hasNext = checkHasNext(memories);
-            nextMemoryRecordAt = getCursorRecordAt(memories);
-            memories = getMemories(memories);
-        }
+        memories = memoryPersistencePort.findPrevMemoryByMemberId(memberId, cursorRecordAt);
+        hasNext = checkHasNext(memories);
+        nextMemoryRecordAt = getCursorRecordAt(memories);
+        memories = getMemories(memories);
         return TimelineSlice.from(memories, nextMemoryRecordAt, hasNext);
     }
 

--- a/module-domain/src/main/java/com/depromeet/reaction/domain/vo/ReactionCount.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/domain/vo/ReactionCount.java
@@ -1,0 +1,16 @@
+package com.depromeet.reaction.domain.vo;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReactionCount {
+    private Long memoryId;
+    private Long reactionCount;
+
+    @Builder
+    public ReactionCount(Long memoryId, Long reactionCount) {
+        this.memoryId = memoryId;
+        this.reactionCount = reactionCount;
+    }
+}

--- a/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/GetReactionUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/in/usecase/GetReactionUseCase.java
@@ -2,6 +2,7 @@ package com.depromeet.reaction.port.in.usecase;
 
 import com.depromeet.reaction.domain.Reaction;
 import com.depromeet.reaction.domain.ReactionPage;
+import com.depromeet.reaction.domain.vo.ReactionCount;
 import java.util.List;
 
 public interface GetReactionUseCase {
@@ -10,6 +11,8 @@ public interface GetReactionUseCase {
     ReactionPage getDetailReactions(Long memoryId, Long cursorId);
 
     Long getDetailReactionsCount(Long memoryId);
+
+    List<ReactionCount> getDetailReactionsCountByMemoryIds(List<Long> memoryIds);
 
     List<Reaction> getReactionsByMemberAndMemory(Long memberId, Long memoryId);
 

--- a/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/port/out/persistence/ReactionPersistencePort.java
@@ -1,6 +1,7 @@
 package com.depromeet.reaction.port.out.persistence;
 
 import com.depromeet.reaction.domain.Reaction;
+import com.depromeet.reaction.domain.vo.ReactionCount;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,8 @@ public interface ReactionPersistencePort {
     List<Reaction> getPagingReactions(Long memoryId, Long cursorId);
 
     Long getAllCountByMemoryId(Long memoryId);
+
+    List<ReactionCount> getAllCountByMemoryIds(List<Long> memoryIds);
 
     Optional<Reaction> getReactionById(Long reactionId);
 

--- a/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
+++ b/module-domain/src/main/java/com/depromeet/reaction/service/ReactionService.java
@@ -7,6 +7,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.reaction.domain.Reaction;
 import com.depromeet.reaction.domain.ReactionPage;
+import com.depromeet.reaction.domain.vo.ReactionCount;
 import com.depromeet.reaction.port.in.command.CreateReactionCommand;
 import com.depromeet.reaction.port.in.usecase.CreateReactionUseCase;
 import com.depromeet.reaction.port.in.usecase.DeleteReactionUseCase;
@@ -92,6 +93,11 @@ public class ReactionService
     @Override
     public Long getDetailReactionsCount(Long memoryId) {
         return reactionPersistencePort.getAllCountByMemoryId(memoryId);
+    }
+
+    @Override
+    public List<ReactionCount> getDetailReactionsCountByMemoryIds(List<Long> memoryIds) {
+        return reactionPersistencePort.getAllCountByMemoryIds(memoryIds);
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/image/FakeImageRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/image/FakeImageRepository.java
@@ -3,6 +3,7 @@ package com.depromeet.mock.image;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.ImageUploadStatus;
+import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import com.depromeet.image.port.out.persistence.ImagePersistencePort;
 import com.depromeet.type.image.ImageErrorType;
 import java.util.ArrayList;
@@ -71,6 +72,11 @@ public class FakeImageRepository implements ImagePersistencePort {
         data.stream()
                 .filter(image -> imageIds.contains(image.getId()))
                 .forEach(Image::updateHasUploaded);
+    }
+
+    @Override
+    public List<MemoryImageUrlVo> findByImageByMemoryIds(List<Long> memoryIds) {
+        return List.of();
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
@@ -108,8 +108,7 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public List<Memory> findPrevMemoryByMemberId(
-            Long memberId, LocalDate cursorRecordAt, LocalDate recordAt) {
+    public List<Memory> findPrevMemoryByMemberId(Long memberId, LocalDate cursorRecordAt) {
         List<Memory> memories;
         if (cursorRecordAt == null) {
             memories =
@@ -117,47 +116,16 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
                             .filter(memory -> memory.getMember().getId().equals(memberId))
                             .toList();
         } else {
-            LocalDate finalCursorRecordAt = cursorRecordAt;
             memories =
                     data.stream()
                             .filter(memory -> memory.getMember().getId().equals(memberId))
-                            .filter(memory -> memory.getRecordAt().isBefore(finalCursorRecordAt))
+                            .filter(memory -> memory.getRecordAt().isBefore(cursorRecordAt))
                             .toList();
         }
         memories = new ArrayList<>(memories);
         memories.sort((memory1, memory2) -> memory2.getRecordAt().compareTo(memory1.getRecordAt()));
         if (memories.size() > 11) {
             memories = memories.subList(0, 11);
-        }
-        return memories;
-    }
-
-    @Override
-    public List<Memory> findNextMemoryByMemberId(
-            Long memberId, LocalDate cursorRecordAt, LocalDate recordAt) {
-        List<Memory> memories;
-        if (cursorRecordAt == null) {
-            memories =
-                    data.stream()
-                            .filter(memory -> memory.getMember().getId().equals(memberId))
-                            .toList();
-            memories = new ArrayList<>(memories);
-            memories.sort(
-                    (memory1, memory2) -> memory2.getRecordAt().compareTo(memory1.getRecordAt()));
-            if (memories.size() > 11) {
-                memories = memories.subList(0, 11);
-            }
-        } else {
-            memories =
-                    data.stream()
-                            .filter(memory -> memory.getMember().getId().equals(memberId))
-                            .filter(memory -> memory.getRecordAt().isAfter(cursorRecordAt))
-                            .toList();
-            if (memories.size() > 10) {
-                memories = memories.subList(0, 10);
-            }
-            memories.sort(
-                    (memory1, memory2) -> memory2.getRecordAt().compareTo(memory1.getRecordAt()));
         }
         return memories;
     }

--- a/module-domain/src/test/java/com/depromeet/service/memory/TimelineServiceTest.java
+++ b/module-domain/src/test/java/com/depromeet/service/memory/TimelineServiceTest.java
@@ -81,7 +81,7 @@ public class TimelineServiceTest {
         LocalDate expectedCursorDate = lastDate.minusDays(10);
         // when
         TimelineSlice timelineSlice =
-                timelineService.getTimelineByMemberIdAndCursorAndDate(memberId, null, null, false);
+                timelineService.getTimelineByMemberIdAndCursorAndDate(memberId, null);
         // then
         List<Memory> timelineContents = timelineSlice.getTimelineContents();
         int pageSize = timelineSlice.getPageSize();
@@ -99,13 +99,12 @@ public class TimelineServiceTest {
     void 타임라인_최초조회이후_cursorRecordAt로_다음_페이지_조회() {
         // given
         TimelineSlice initTimelineSlice =
-                timelineService.getTimelineByMemberIdAndCursorAndDate(memberId, null, null, false);
+                timelineService.getTimelineByMemberIdAndCursorAndDate(memberId, null);
         LocalDate initCursorRecordAt = initTimelineSlice.getCursorRecordAt();
 
         // when
         TimelineSlice timelineSlice =
-                timelineService.getTimelineByMemberIdAndCursorAndDate(
-                        memberId, initCursorRecordAt, null, false);
+                timelineService.getTimelineByMemberIdAndCursorAndDate(memberId, initCursorRecordAt);
         // then
         List<Memory> timelineContents = timelineSlice.getTimelineContents();
         int pageSize = timelineSlice.getPageSize();

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
@@ -5,8 +5,10 @@ import static com.depromeet.memory.entity.QMemoryEntity.memoryEntity;
 
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.ImageUploadStatus;
+import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import com.depromeet.image.entity.ImageEntity;
 import com.depromeet.image.port.out.persistence.ImagePersistencePort;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.List;
@@ -42,6 +44,20 @@ public class ImageRepository implements ImagePersistencePort {
                 .set(imageEntity.imageUploadStatus, ImageUploadStatus.UPLOADED)
                 .where(imageEntity.id.in(imageIds))
                 .execute();
+    }
+
+    @Override
+    public List<MemoryImageUrlVo> findByImageByMemoryIds(List<Long> memoryIds) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                MemoryImageUrlVo.class,
+                                imageEntity.memory.id.as("memoryId"),
+                                imageEntity.imageName.as("imageName")))
+                .from(imageEntity)
+                .where(imageEntity.memory.id.in(memoryIds))
+                .groupBy(imageEntity.memory)
+                .fetch();
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/entity/MemoryEntity.java
@@ -7,8 +7,6 @@ import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.domain.Stroke;
 import com.depromeet.pool.entity.PoolEntity;
-import com.depromeet.reaction.domain.Reaction;
-import com.depromeet.reaction.entity.ReactionEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -51,9 +49,6 @@ public class MemoryEntity {
     @OneToMany(mappedBy = "memory")
     private List<ImageEntity> images = new ArrayList<>();
 
-    @OneToMany(mappedBy = "memory")
-    private List<ReactionEntity> reactions = new ArrayList<>();
-
     @NotNull private LocalDate recordAt;
 
     @NotNull private LocalTime startTime;
@@ -73,7 +68,6 @@ public class MemoryEntity {
             MemoryDetailEntity memoryDetail,
             List<StrokeEntity> strokes,
             List<ImageEntity> images,
-            List<ReactionEntity> reactions,
             LocalDate recordAt,
             LocalTime startTime,
             LocalTime endTime,
@@ -85,7 +79,6 @@ public class MemoryEntity {
         this.memoryDetail = memoryDetail;
         this.strokes = strokes;
         this.images = images;
-        this.reactions = reactions;
         this.recordAt = recordAt;
         this.startTime = startTime;
         this.endTime = endTime;
@@ -101,7 +94,6 @@ public class MemoryEntity {
                 .memoryDetail(getMemoryDetailEntityOrNull(memory))
                 .strokes(getStrokeEntitiesOrNull(memory))
                 .images(getImageEntitiesOrNull(memory))
-                .reactions(getReactionEntitiesOrNull(memory))
                 .recordAt(memory.getRecordAt())
                 .startTime(memory.getStartTime())
                 .endTime(memory.getEndTime())
@@ -132,12 +124,6 @@ public class MemoryEntity {
                 : null;
     }
 
-    private static List<ReactionEntity> getReactionEntitiesOrNull(Memory memory) {
-        return memory.getImages() != null
-                ? memory.getReactions().stream().map(ReactionEntity::pureFrom).toList()
-                : null;
-    }
-
     public Memory toModel() {
         return Memory.builder()
                 .id(this.id)
@@ -146,7 +132,21 @@ public class MemoryEntity {
                 .memoryDetail(getMemoryDetailOrNull())
                 .strokes(getStrokeListOrNull())
                 .images(getImageListOrNull())
-                .reactions(getReactionOrNull())
+                .recordAt(this.recordAt)
+                .startTime(this.startTime)
+                .endTime(this.endTime)
+                .lane(this.lane)
+                .diary(this.diary)
+                .build();
+    }
+
+    public Memory toModelForTimeline() {
+        return Memory.builder()
+                .id(this.id)
+                .member(this.member.toModel())
+                .pool(this.pool != null ? this.pool.toModel() : null)
+                .memoryDetail(getMemoryDetailOrNull())
+                .strokes(getStrokeListOrNull())
                 .recordAt(this.recordAt)
                 .startTime(this.startTime)
                 .endTime(this.endTime)
@@ -203,12 +203,6 @@ public class MemoryEntity {
     private List<Stroke> getStrokeListOrNull() {
         return this.strokes != null
                 ? this.strokes.stream().map(StrokeEntity::pureToModel).toList()
-                : null;
-    }
-
-    private List<Reaction> getReactionOrNull() {
-        return this.reactions != null
-                ? this.reactions.stream().map(ReactionEntity::pureToModel).toList()
                 : null;
     }
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -107,8 +107,7 @@ public class MemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public List<Memory> findPrevMemoryByMemberId(
-            Long memberId, LocalDate cursorRecordAt, LocalDate recordAt) {
+    public List<Memory> findPrevMemoryByMemberId(Long memberId, LocalDate cursorRecordAt) {
         List<MemoryEntity> memories =
                 queryFactory
                         .selectFrom(memory)
@@ -120,38 +119,11 @@ public class MemoryRepository implements MemoryPersistencePort {
                         .fetchJoin()
                         .leftJoin(memory.strokes)
                         .fetchJoin()
-                        .where(
-                                memory.member.id.eq(memberId),
-                                ltCursorRecordAt(cursorRecordAt),
-                                loeRecordAt(recordAt))
+                        .where(memory.member.id.eq(memberId), ltCursorRecordAt(cursorRecordAt))
                         .limit(11)
                         .orderBy(memory.recordAt.desc())
                         .fetch();
-        return toModel(memories);
-    }
-
-    @Override
-    public List<Memory> findNextMemoryByMemberId(
-            Long memberId, LocalDate cursorRecordAt, LocalDate recordAt) {
-        List<MemoryEntity> memories =
-                queryFactory
-                        .selectFrom(memory)
-                        .join(memory.member)
-                        .fetchJoin()
-                        .leftJoin(memory.pool)
-                        .fetchJoin()
-                        .leftJoin(memory.memoryDetail)
-                        .fetchJoin()
-                        .leftJoin(memory.strokes)
-                        .fetchJoin()
-                        .where(
-                                memory.member.id.eq(memberId),
-                                gtCursorRecordAt(cursorRecordAt),
-                                goeRecordAt(recordAt))
-                        .limit(11)
-                        .orderBy(memory.recordAt.asc())
-                        .fetch();
-        return toModel(memories);
+        return toTimelineModel(memories);
     }
 
     @Override
@@ -269,5 +241,9 @@ public class MemoryRepository implements MemoryPersistencePort {
 
     private List<Memory> toModel(List<MemoryEntity> memoryEntities) {
         return memoryEntities.stream().map(MemoryEntity::toModel).toList();
+    }
+
+    private List<Memory> toTimelineModel(List<MemoryEntity> memoryEntities) {
+        return memoryEntities.stream().map(MemoryEntity::toModelForTimeline).toList();
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
@@ -5,9 +5,12 @@ import static com.depromeet.memory.entity.QMemoryEntity.*;
 import static com.depromeet.reaction.entity.QReactionEntity.*;
 
 import com.depromeet.member.entity.QMemberEntity;
+import com.depromeet.memory.entity.QMemoryEntity;
 import com.depromeet.reaction.domain.Reaction;
+import com.depromeet.reaction.domain.vo.ReactionCount;
 import com.depromeet.reaction.entity.ReactionEntity;
 import com.depromeet.reaction.port.out.persistence.ReactionPersistencePort;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -113,6 +116,21 @@ public class ReactionRepository implements ReactionPersistencePort {
                 .from(reactionEntity)
                 .where(memoryEq(memoryId))
                 .fetchOne();
+    }
+
+    @Override
+    public List<ReactionCount> getAllCountByMemoryIds(List<Long> memoryIds) {
+        QMemoryEntity memoryEntity = QMemoryEntity.memoryEntity;
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                ReactionCount.class,
+                                memoryEntity.id.as("memoryId"),
+                                reactionEntity.id.count().as("reactionCount")))
+                .from(reactionEntity)
+                .join(reactionEntity.memory, memoryEntity)
+                .where(memoryEntity.id.in(memoryIds))
+                .fetch();
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/test/java/com/depromeet/memory/repository/MemoryRepositoryTest.java
+++ b/module-infrastructure/persistence-database/src/test/java/com/depromeet/memory/repository/MemoryRepositoryTest.java
@@ -68,7 +68,7 @@ public class MemoryRepositoryTest {
     @Test
     void findPrevMemoryByMemberId로_최근_날짜_이전_11일_recordAt_Desc로_가져오는지_테스트() {
         // when
-        List<Memory> result = memoryRepository.findPrevMemoryByMemberId(member.getId(), null, null);
+        List<Memory> result = memoryRepository.findPrevMemoryByMemberId(member.getId(), null);
         Memory lastMemory = result.getLast();
 
         // then
@@ -77,57 +77,18 @@ public class MemoryRepositoryTest {
     }
 
     @Test
-    void findPrevMemoryByMemberId로_지정한_날짜_이전_11일_recordAt_Desc로_가져오는지_테스트() {
-        // given
-        LocalDate recordAt = LocalDate.of(2024, 7, 25);
-
-        // when
-        List<Memory> result =
-                memoryRepository.findPrevMemoryByMemberId(member.getId(), null, recordAt);
-        Memory lastMemory = result.getLast();
-
-        // then
-        assertThat(result.size()).isEqualTo(11);
-        assertThat(lastMemory.getRecordAt()).isEqualTo(recordAt.minusDays(10));
-    }
-
-    @Test
     void 최초_조회_이후_findPrevMemoryByMemberId로_다음_데이터를_가져오는지_테스트() {
         // given
-        LocalDate recordAt = LocalDate.of(2024, 8, 31);
-
-        List<Memory> memories =
-                memoryRepository.findPrevMemoryByMemberId(member.getId(), null, recordAt);
+        List<Memory> memories = memoryRepository.findPrevMemoryByMemberId(member.getId(), null);
         Memory lastDate = memories.getLast();
 
         // when
         List<Memory> resultMemories =
-                memoryRepository.findPrevMemoryByMemberId(
-                        member.getId(), lastDate.getRecordAt(), null);
+                memoryRepository.findPrevMemoryByMemberId(member.getId(), lastDate.getRecordAt());
 
         // then
         assertThat(resultMemories.size()).isEqualTo(11);
         assertThat(resultMemories.getLast().getRecordAt())
                 .isEqualTo(lastDate.getRecordAt().minusDays(11));
-    }
-
-    @Test
-    void 최초_조회_이후_findNextMemoryByMemberId로_다음_데이터를_가져오는지_확인() {
-        // given
-        LocalDate recordAt = LocalDate.of(2024, 7, 15);
-
-        List<Memory> memories =
-                memoryRepository.findPrevMemoryByMemberId(member.getId(), null, recordAt);
-        Memory cursorMemory = memories.getFirst();
-
-        // when
-        List<Memory> resultMemories =
-                memoryRepository.findNextMemoryByMemberId(
-                        member.getId(), cursorMemory.getRecordAt(), null);
-
-        // then
-        assertThat(resultMemories.size()).isEqualTo(11);
-        assertThat(resultMemories.getLast().getRecordAt())
-                .isEqualTo(cursorMemory.getRecordAt().plusDays(11));
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -63,8 +63,7 @@ public class MemoryController implements MemoryApi {
                     @DateTimeFormat(pattern = "yyyy-MM-dd")
                     LocalDate cursorRecordAt) {
         TimelineSliceResponse result =
-                memoryFacade.getTimelineByMemberIdAndCursorAndDate(
-                        memberId, cursorRecordAt, null, false);
+                memoryFacade.getTimelineByMemberIdAndCursorAndDate(memberId, cursorRecordAt);
         return ApiResponse.success(MemorySuccessType.GET_TIMELINE_SUCCESS, result);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
@@ -1,5 +1,6 @@
 package com.depromeet.memory.mapper;
 
+import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import com.depromeet.member.domain.Member;
 import com.depromeet.memory.domain.vo.TimelineSlice;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
@@ -12,6 +13,7 @@ import com.depromeet.memory.port.in.command.CreateMemoryCommand;
 import com.depromeet.memory.port.in.command.CreateStrokeCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
 import com.depromeet.memory.port.in.command.UpdateStrokeCommand;
+import com.depromeet.reaction.domain.vo.ReactionCount;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -80,10 +82,20 @@ public class MemoryMapper {
     }
 
     public static TimelineSliceResponse toSliceResponse(
-            Member member, TimelineSlice timelineSlice) {
+            Member member,
+            TimelineSlice timelineSlice,
+            List<ReactionCount> reactionCounts,
+            List<MemoryImageUrlVo> memoryImageUrls,
+            String imageOrigin) {
         List<TimelineResponse> result =
                 timelineSlice.getTimelineContents().stream()
-                        .map(TimelineResponse::mapToTimelineResponseDto)
+                        .map(
+                                memory ->
+                                        TimelineResponse.mapToTimelineResponseDto(
+                                                memory,
+                                                reactionCounts,
+                                                memoryImageUrls,
+                                                imageOrigin))
                         .toList();
         return TimelineSliceResponse.builder()
                 .content(result)


### PR DESCRIPTION
## 🌱 관련 이슈

- close #356 

## 📌 작업 내용 및 특이사항
- 타임라인 속도 개선을 하였습니다. 
- 결론적으로 말하자면 코드에는 큰 변화는 없고 (불필요한 로직 제거, reaction count, image 조회 방법만 변경) 복합 인덱스가 하나 추가되어야 합니다
- 타임라인 속도를 개선하기 위해 의심되는 부분들 부터 제거를 시작했습니다.
  - 타임라인에서 reaction count 조회 시 List<Reaction>조회 후 list.size()로 계산하지 않고 select count로 조회 후, 어플리케이션 레벨에서 매핑
  - memory에 해당하는 image 전체 조회 후, 가장 먼저 저장된 이미지를 응답값으로 보내는 대신 처음부터 1개씩만 조회 후 어플리케이션 레벨에서 매핑
- 그러나 위의 시도들로는 큰 변화가 없었습니다.
- 이후 memory를 조회하는 로직의 SQL 실행 계획을 분석한 결과 아래와 같은 결과가 나왔습니다. 
![before index sql explain](https://github.com/user-attachments/assets/cb0e6d19-9bc8-4304-bb65-b4f650f8d867)
- filesort와 full scan으로 데이터를 조회하는 것을 확인하였고 이를 개선하기 위해 민철님과 같은 방식으로 복합 인덱스를 추가하기로 하였습니다.
```sql
CREATE INDEX idx_member_record on memory_entity (member_id, record_at DESC);
```

이후 인덱스 조회 전과 후의 sql속도 차이를 확인해본 결과 인덱스를 추가한 후가 더 속도가 빠르다는 것을 볼 수 있었습니다.
![복합 인덱스 적용 전](https://github.com/user-attachments/assets/2b37c523-4776-4a23-8f2e-a196fc3da3f9)
(두번째 칼럼이 duration으로 숫자가 작을수록 조회에 시간이 짧게 들었다는 것을 뜻합니다.)

아래는 JMeter 실행 결과입니다. 시나리오는 100명의 유저가 10개씩의 memory 데이터를 입력한 상태로 가정하였고 thread number 1000, 실행 시간 1초 (1000명의 유저가 1초에 몰린다는 의미입니다.), 10회 루프 로 설정하였습니다.

인덱스 적용 전
![image](https://github.com/user-attachments/assets/49664b5f-3d69-43ab-a3c0-efec6cae63d2)

인덱스 적용 후
![image](https://github.com/user-attachments/assets/8beda0b6-1bdf-4e4e-be4f-3001414a57e3)

확인 결과 throughput, 전송 KB 가 늘은 것을 확인할 수 있습니다

## 📝 참고사항
- 배포 전, 아래와 같은 sql을 적용해야 합니다. 
```sql
CREATE INDEX idx_member_record on memory_entity (member_id, record_at DESC);
```

- 추가적으로 타임라인에서 불필요한 로직을 제거하였습니다.