### PR TITLE
feat: 수영장 검색 API 관련 성능 체크 및 MATCH-AGAINST 함수 추가

### DIFF
--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
@@ -14,6 +14,7 @@ import com.depromeet.pool.entity.FavoritePoolEntity;
 import com.depromeet.pool.entity.PoolEntity;
 import com.depromeet.pool.entity.PoolSearchEntity;
 import com.depromeet.pool.port.out.persistence.PoolPersistencePort;
+import com.depromeet.util.CustomFunction;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -40,7 +41,8 @@ public class PoolRepository implements PoolPersistencePort {
                 queryFactory
                         .selectFrom(poolEntity)
                         .where(
-                                nameLike(nameQuery),
+                                CustomFunction.match(poolEntity.name, nameQuery),
+                                // nameLike(nameQuery),
                                 poolIdNotIn(favoritePoolIds),
                                 goePoolId(cursorId))
                         .limit(limit + 1)

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/pool/repository/PoolRepository.java
@@ -42,7 +42,6 @@ public class PoolRepository implements PoolPersistencePort {
                         .selectFrom(poolEntity)
                         .where(
                                 CustomFunction.match(poolEntity.name, nameQuery),
-                                // nameLike(nameQuery),
                                 poolIdNotIn(favoritePoolIds),
                                 goePoolId(cursorId))
                         .limit(limit + 1)
@@ -112,7 +111,9 @@ public class PoolRepository implements PoolPersistencePort {
                         .fetchJoin()
                         .join(favoritePoolEntity.pool, poolEntity)
                         .fetchJoin()
-                        .where(favoritePoolMemberEq(memberId), nameLike(nameQuery))
+                        .where(
+                                favoritePoolMemberEq(memberId),
+                                CustomFunction.match(poolEntity.name, nameQuery))
                         .fetch();
 
         return favoritePoolEntities.stream().map(FavoritePoolEntity::toModel).toList();
@@ -159,16 +160,6 @@ public class PoolRepository implements PoolPersistencePort {
     @Override
     public void deleteAllPoolSearchLogByMemberId(Long memberId) {
         queryFactory.delete(poolSearchEntity).where(poolSearchMemberEq(memberId)).execute();
-    }
-
-    private BooleanExpression nameLike(String query) {
-        BooleanExpression whereExpression = poolEntity.isNotNull();
-
-        if (query != null && !query.isEmpty()) {
-            whereExpression = poolEntity.name.contains(query);
-        }
-
-        return whereExpression;
     }
 
     private BooleanExpression poolIdNotIn(Set<Long> favoritePoolIds) {

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/util/CustomFunction.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/util/CustomFunction.java
@@ -1,0 +1,20 @@
+package com.depromeet.util;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
+
+public class CustomFunction {
+    public static BooleanExpression match(StringPath target, String keyword) {
+        if (keyword == null) {
+            return null;
+        }
+
+        return Expressions.numberTemplate(
+                        java.lang.Double.class,
+                        "FUNCTION('MATCH_AGAINST', {0}, {1})",
+                        target,
+                        keyword)
+                .gt(0);
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/util/MatchFunctionContributor.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/util/MatchFunctionContributor.java
@@ -1,0 +1,23 @@
+package com.depromeet.util;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.StandardBasicTypes;
+
+public class MatchFunctionContributor implements FunctionContributor {
+    private static final String FUNCTION_NAME = "MATCH_AGAINST";
+    private static final String FUNCTION_PATTERN = "MATCH (?1) AGAINST (?2 IN BOOLEAN MODE)";
+
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        functionContributions
+                .getFunctionRegistry()
+                .registerPattern(
+                        FUNCTION_NAME,
+                        FUNCTION_PATTERN,
+                        functionContributions
+                                .getTypeConfiguration()
+                                .getBasicTypeRegistry()
+                                .resolve(StandardBasicTypes.DOUBLE));
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/module-infrastructure/persistence-database/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.depromeet.util.MatchFunctionContributor


### PR DESCRIPTION
## 🌱 관련 이슈

- close #367 

## 📌 작업 내용 및 특이사항
- 수영장 검색 API 성능을 향상시키기 위해 N-gram 기반의 Full Text Index 도입을 시도하였습니다.
- 하지만 Full Text Index는 데이터가 얼마 없을 때는 오히려 성능이 like '%검색어%' 보다 2~30%가량 느린 것을 확인하였습니다.
- 따라서 데이터가 많이 쌓인 후에 Full Text Index를 적용하도록 하고 테스트하면서 추가된 MATCH-AGAINST 커스텀 함수 메소드는 그대로 놔두도록 하겠습니다!
- 테스트 결과는 아래 참고사항을 확인해주세요!

## 📝 참고사항
### 각 카테고리의 첫번째 사진은 100명의 유저가 1초동안 조회하는 테스트이고
두번째 사진은 10명이 10초동안 조회하는 테스트입니다.

`[LIKE '%검색어%' 방식의 성능 체크]`
<img width="932" alt="스크린샷 2024-09-06 오후 2 09 38" src="https://github.com/user-attachments/assets/ff6e45d5-8bcf-4779-a182-d03fdee12599">
<img width="912" alt="스크린샷 2024-09-06 오후 2 09 49" src="https://github.com/user-attachments/assets/b384294a-667d-49c0-a8b5-d91454f22f20">

<br>
<br>

`[N-gram Full Text Index 기반 방식의 성능 체크]`
<img width="946" alt="스크린샷 2024-09-06 오후 2 10 09" src="https://github.com/user-attachments/assets/0ac5c519-acc7-426e-951c-8d17961d17e7">
<img width="901" alt="스크린샷 2024-09-06 오후 2 10 28" src="https://github.com/user-attachments/assets/d2513185-4903-4fb3-bf79-65f88782ca8a">
