### PR TITLE
hotfix: 타임라인 조회 시 only_full_group_by 에러 해결

### DIFF
--- a/module-domain/src/main/java/com/depromeet/image/domain/vo/MemoryImageUrlVo.java
+++ b/module-domain/src/main/java/com/depromeet/image/domain/vo/MemoryImageUrlVo.java
@@ -1,3 +1,3 @@
 package com.depromeet.image.domain.vo;
 
-public record MemoryImageUrlVo(Long memoryId, String imageName) {}
+public record MemoryImageUrlVo(Long memoryId, Long imageId, String imageName) {}

--- a/module-domain/src/main/java/com/depromeet/image/port/in/ImageGetUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/image/port/in/ImageGetUseCase.java
@@ -3,9 +3,10 @@ package com.depromeet.image.port.in;
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import java.util.List;
+import java.util.Map;
 
 public interface ImageGetUseCase {
     List<Image> findImagesByMemoryId(Long memoryId);
 
-    List<MemoryImageUrlVo> findImagesByMemoryIds(List<Long> memoryIds);
+    Map<Long, MemoryImageUrlVo> findImagesByMemoryIds(List<Long> memoryIds);
 }

--- a/module-domain/src/main/java/com/depromeet/image/service/ImageGetService.java
+++ b/module-domain/src/main/java/com/depromeet/image/service/ImageGetService.java
@@ -5,6 +5,9 @@ import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import com.depromeet.image.port.in.ImageGetUseCase;
 import com.depromeet.image.port.out.persistence.ImagePersistencePort;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,7 +24,17 @@ public class ImageGetService implements ImageGetUseCase {
     }
 
     @Override
-    public List<MemoryImageUrlVo> findImagesByMemoryIds(List<Long> memoryIds) {
-        return imagePersistencePort.findByImageByMemoryIds(memoryIds);
+    public Map<Long, MemoryImageUrlVo> findImagesByMemoryIds(List<Long> memoryIds) {
+        List<MemoryImageUrlVo> imageUrlVos = imagePersistencePort.findByImageByMemoryIds(memoryIds);
+
+        return imageUrlVos.stream()
+                .collect(
+                        Collectors.toMap(
+                                MemoryImageUrlVo::memoryId,
+                                Function.identity(),
+                                (imageUrlVo1, imageUrlVo2) ->
+                                        imageUrlVo1.imageId() < imageUrlVo2.imageId()
+                                                ? imageUrlVo1
+                                                : imageUrlVo2));
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/image/repository/ImageRepository.java
@@ -53,10 +53,10 @@ public class ImageRepository implements ImagePersistencePort {
                         Projections.constructor(
                                 MemoryImageUrlVo.class,
                                 imageEntity.memory.id.as("memoryId"),
+                                imageEntity.id.as("imageId"),
                                 imageEntity.imageName.as("imageName")))
                 .from(imageEntity)
                 .where(imageEntity.memory.id.in(memoryIds))
-                .groupBy(imageEntity.memory)
                 .fetch();
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -79,13 +79,12 @@ public record TimelineResponse(
     public static TimelineResponse mapToTimelineResponseDto(
             Memory memory,
             List<ReactionCount> reactionCounts,
-            List<MemoryImageUrlVo> memoryImageUrls,
+            Map<Long, MemoryImageUrlVo> memoryImageUrls,
             String imageOrigin) {
         Integer totalDistance = memory.calculateTotalDistance();
         Short lane = memory.getLane() != null ? memory.getLane() : 0;
 
         Map<Long, Long> reactionCountMap = getMapReactionCount(reactionCounts);
-        Map<Long, String> imageMap = getImageMap(memoryImageUrls);
 
         return TimelineResponse.builder()
                 .memoryId(memory.getId())
@@ -99,23 +98,18 @@ public record TimelineResponse(
                 .kcal(getKcalFromMemoryDetail(memory))
                 .type(memory.classifyType())
                 .strokes(strokeToDto(memory.getStrokes(), lane))
-                .imageUrl(getImageUrl(memory, imageMap, imageOrigin))
+                .imageUrl(getImageUrl(memory, memoryImageUrls, imageOrigin))
                 .reactionCount(getReactionCount(memory.getId(), reactionCountMap))
                 .build();
     }
 
     private static String getImageUrl(
-            Memory memory, Map<Long, String> imageMap, String imageOrigin) {
-        String image = imageMap.getOrDefault(memory.getId(), null);
+            Memory memory, Map<Long, MemoryImageUrlVo> imageMap, String imageOrigin) {
+        MemoryImageUrlVo image = imageMap.getOrDefault(memory.getId(), null);
         if (image != null) {
-            return imageOrigin + "/" + image;
+            return imageOrigin + "/" + image.imageName();
         }
-        return imageOrigin;
-    }
-
-    private static Map<Long, String> getImageMap(List<MemoryImageUrlVo> memoryImageUrls) {
-        return memoryImageUrls.stream()
-                .collect(Collectors.toMap(MemoryImageUrlVo::memoryId, MemoryImageUrlVo::imageName));
+        return null;
     }
 
     private static Map<Long, Long> getMapReactionCount(List<ReactionCount> reactionCounts) {

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -31,6 +31,7 @@ import com.depromeet.reaction.port.in.usecase.GetReactionUseCase;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -113,7 +114,8 @@ public class MemoryFacade {
                         .mapToLong(Memory::getId)
                         .boxed()
                         .toList();
-        List<MemoryImageUrlVo> memoryImageUrls = imageGetUseCase.findImagesByMemoryIds(memoryIds);
+        Map<Long, MemoryImageUrlVo> memoryImageUrls =
+                imageGetUseCase.findImagesByMemoryIds(memoryIds);
         List<ReactionCount> reactionCounts =
                 getReactionUseCase.getDetailReactionsCountByMemoryIds(memoryIds);
 

--- a/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
@@ -16,6 +16,7 @@ import com.depromeet.memory.port.in.command.UpdateStrokeCommand;
 import com.depromeet.reaction.domain.vo.ReactionCount;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 
 public class MemoryMapper {
     public static CreateStrokeCommand toCommand(StrokeCreateRequest request) {
@@ -85,7 +86,7 @@ public class MemoryMapper {
             Member member,
             TimelineSlice timelineSlice,
             List<ReactionCount> reactionCounts,
-            List<MemoryImageUrlVo> memoryImageUrls,
+            Map<Long, MemoryImageUrlVo> memoryImageUrls,
             String imageOrigin) {
         List<TimelineResponse> result =
                 timelineSlice.getTimelineContents().stream()


### PR DESCRIPTION
## 🌱 관련 이슈

- close #371

## 📌 작업 내용 및 특이사항
- 타임라인에서 이미지 조회 시 only_full_group_by 에러 발생

원인
select i.memory_id, i.image_name from image_entity i where i.memory_id in (...) group by i.memory_id 에서 group by 가 memory_id 만 있어서 오류 남

현재는 memoryIds 에 해당하는 이미지 전체 조회 후 memory에 해당하는 이미지 하나만 필터링 하는 것으로 조회

## 📝 참고사항
-