### PR TITLE
feat: 사용자 차단 해제 API 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistCommandUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistCommandUseCase.java
@@ -4,4 +4,6 @@ import com.depromeet.blacklist.domain.Blacklist;
 
 public interface BlacklistCommandUseCase {
     Blacklist blackMember(Long memberId, Long blackMemberId);
+
+    void unblackMember(Long memberId, Long blackMemberId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
@@ -6,4 +6,6 @@ public interface BlacklistPersistencePort {
     Blacklist save(Blacklist blacklist);
 
     boolean existsByMemberIdAndBlackMemberId(Long memberId, Long blackMemberId);
+
+    void unblackMember(Long memberId, Long blackMemberId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
@@ -26,6 +26,12 @@ public class BlacklistService implements BlacklistQueryUseCase, BlacklistCommand
     }
 
     @Override
+    @Transactional
+    public void unblackMember(Long memberId, Long blackMemberId) {
+        blacklistPersistencePort.unblackMember(memberId, blackMemberId);
+    }
+
+    @Override
     public boolean checkBlackMember(Long memberId, Long blackMemberId) {
         return blacklistPersistencePort.existsByMemberIdAndBlackMemberId(memberId, blackMemberId);
     }

--- a/module-independent/src/main/java/com/depromeet/type/blacklist/BlacklistSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/blacklist/BlacklistSuccessType.java
@@ -3,7 +3,8 @@ package com.depromeet.type.blacklist;
 import com.depromeet.type.SuccessType;
 
 public enum BlacklistSuccessType implements SuccessType {
-    BLACK_MEMBER_SUCCESS("BLACK_1", "사용자를 성공적으로 차단하였습니다");
+    BLACK_MEMBER_SUCCESS("BLACK_1", "사용자를 성공적으로 차단하였습니다"),
+    UNBLACK_MEMBER_SUCCESS("BLACK_2", "사용자를 차단 해제하였습니다");
 
     private final String code;
     private final String message;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistJpaRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistJpaRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlacklistJpaRepository extends JpaRepository<BlacklistEntity, Long> {
     boolean existsByMemberIdAndBlackMemberId(Long memberId, Long blackMemberId);
+
+    void deleteByMemberIdAndBlackMemberId(Long memberId, Long blackMemberId);
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistRepository.java
@@ -20,4 +20,9 @@ public class BlacklistRepository implements BlacklistPersistencePort {
     public boolean existsByMemberIdAndBlackMemberId(Long memberId, Long blackMemberId) {
         return blacklistJpaRepository.existsByMemberIdAndBlackMemberId(memberId, blackMemberId);
     }
+
+    @Override
+    public void unblackMember(Long memberId, Long blackMemberId) {
+        blacklistJpaRepository.deleteByMemberIdAndBlackMemberId(memberId, blackMemberId);
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistApi.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistApi.java
@@ -6,6 +6,7 @@ import com.depromeet.member.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "차단(Blacklist)")
@@ -13,4 +14,8 @@ public interface BlacklistApi {
     @Operation(summary = "사용자 차단")
     ApiResponse<?> blackMember(
             @LoginMember Long memberId, @Valid @RequestBody BlackMemberRequest request);
+
+    @Operation(summary = "사용자 차단 해제")
+    ApiResponse<?> unblackMember(
+            @LoginMember Long memberId, @PathVariable("blackMemberId") Long blackMemberId);
 }

--- a/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistController.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistController.java
@@ -2,11 +2,14 @@ package com.depromeet.blacklist.api;
 
 import com.depromeet.blacklist.dto.request.BlackMemberRequest;
 import com.depromeet.blacklist.facade.BlacklistFacade;
+import com.depromeet.config.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.type.blacklist.BlacklistSuccessType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,14 +17,23 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/member/black")
+@RequestMapping("/member")
 public class BlacklistController implements BlacklistApi {
     private final BlacklistFacade blacklistFacade;
 
-    @PostMapping
+    @PostMapping("/black")
+    @Logging(item = "Blacklist", action = "POST")
     public ApiResponse<?> blackMember(
             @LoginMember Long memberId, @Valid @RequestBody BlackMemberRequest request) {
         blacklistFacade.blackMember(memberId, request);
         return ApiResponse.success(BlacklistSuccessType.BLACK_MEMBER_SUCCESS);
+    }
+
+    @DeleteMapping("/{blackMemberId}/black")
+    @Logging(item = "Blacklist", action = "DELETE")
+    public ApiResponse<?> unblackMember(
+            @LoginMember Long memberId, @PathVariable("blackMemberId") Long blackMemberId) {
+        blacklistFacade.unblackMember(memberId, blackMemberId);
+        return ApiResponse.success(BlacklistSuccessType.UNBLACK_MEMBER_SUCCESS);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
@@ -25,4 +25,8 @@ public class BlacklistFacade {
 
         blacklistCommandUseCase.blackMember(memberId, blackMemberId);
     }
+
+    public void unblackMember(Long memberId, Long blackMemberId) {
+        blacklistCommandUseCase.unblackMember(memberId, blackMemberId);
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -79,6 +79,7 @@ public class MemoryController implements MemoryApi {
     }
 
     @DeleteMapping("/{memoryId}")
+    @Logging(item = "Memory", action = "DELETE")
     public ApiResponse<?> delete(
             @LoginMember Long memberId, @PathVariable("memoryId") Long memoryId) {
         memoryFacade.deleteById(memberId, memoryId);


### PR DESCRIPTION
## 🌱 관련 이슈

- close #383 

## 📌 작업 내용 및 특이사항
- 사용자 차단 해제 API를 구현하였습니다
- 차단되어 있던 여부와 상관 없이 오버헤드를 줄이기 위해 해당 id로 들어온 자원을 삭제하는 쿼리만 남깁니다.
- 만약 있는지 없는지 확인할시, 있을 경우 2번의 쿼리가 발생하고 없을 경우 1번의 쿼리만 수행되기 때문에 평균 수행 속도는 Validation이 없는 쪽이 더 효율적이라고 판단하였습니다.

## 📝 참고사항
`[사용자 차단 해제 성공]`
<img width="373" alt="image" src="https://github.com/user-attachments/assets/b3990679-42a2-4c85-9c30-ece0cd2305c9">
