### PR TITLE
feat: 신고 구글 스프레드시트 연동 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberIdAndNickname.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberIdAndNickname.java
@@ -1,0 +1,3 @@
+package com.depromeet.member.domain.vo;
+
+public record MemberIdAndNickname(Long id, String nickname) {}

--- a/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/in/usecase/MemberUseCase.java
@@ -1,6 +1,7 @@
 package com.depromeet.member.port.in.usecase;
 
 import com.depromeet.member.domain.Member;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 
@@ -16,4 +17,6 @@ public interface MemberUseCase {
     Member findByProviderId(String providerId);
 
     Member createMemberBy(SocialMemberCommand command);
+
+    MemberIdAndNickname findIdAndNicknameById(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
@@ -2,6 +2,7 @@ package com.depromeet.member.port.out.persistence;
 
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
 import java.util.Optional;
@@ -30,4 +31,6 @@ public interface MemberPersistencePort {
     Optional<Member> update(UpdateMemberCommand command);
 
     Optional<Member> updateProfileImageUrl(Long memberId, String profileImageUrl);
+
+    Optional<MemberIdAndNickname> findIdAndNicknameById(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.depromeet.exception.NotFoundException;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.MemberRole;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
@@ -80,6 +81,13 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUp
                         .profileImageUrl(command.defaultProfile())
                         .build();
         return memberPersistencePort.save(member);
+    }
+
+    @Override
+    public MemberIdAndNickname findIdAndNicknameById(Long memberId) {
+        return memberPersistencePort
+                .findIdAndNicknameById(memberId)
+                .orElseThrow(() -> new NotFoundException(MemberErrorType.NOT_FOUND));
     }
 
     @Override

--- a/module-domain/src/main/java/com/depromeet/memory/domain/vo/MemoryIdAndDiaryAndMember.java
+++ b/module-domain/src/main/java/com/depromeet/memory/domain/vo/MemoryIdAndDiaryAndMember.java
@@ -1,0 +1,5 @@
+package com.depromeet.memory.domain.vo;
+
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
+
+public record MemoryIdAndDiaryAndMember(Long id, String diary, MemberIdAndNickname member) {}

--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
@@ -2,6 +2,7 @@ package com.depromeet.memory.port.in.usecase;
 
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.vo.MemoryAndDetailId;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
 import com.depromeet.memory.domain.vo.MemoryInfo;
 import java.util.List;
 
@@ -17,4 +18,6 @@ public interface GetMemoryUseCase {
     MemoryInfo findByIdWithPrevNext(Long requestMemberId, Long memoryId);
 
     MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId);
+
+    MemoryIdAndDiaryAndMember findIdAndNicknameById(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -2,6 +2,7 @@ package com.depromeet.memory.port.out.persistence;
 
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.vo.MemoryAndDetailId;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -36,4 +37,6 @@ public interface MemoryPersistencePort {
     MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId);
 
     void deleteById(Long memoryId);
+
+    Optional<MemoryIdAndDiaryAndMember> findIdAndNicknameById(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -10,6 +10,7 @@ import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.MemoryDetail;
 import com.depromeet.memory.domain.Stroke;
 import com.depromeet.memory.domain.vo.MemoryAndDetailId;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
 import com.depromeet.memory.domain.vo.MemoryInfo;
 import com.depromeet.memory.port.in.command.CreateMemoryCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
@@ -108,6 +109,13 @@ public class MemoryService
     @Override
     public MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId) {
         return memoryPersistencePort.findMemoryAndDetailIdsByMemberId(memberId);
+    }
+
+    @Override
+    public MemoryIdAndDiaryAndMember findIdAndNicknameById(Long memberId) {
+        return memoryPersistencePort
+                .findIdAndNicknameById(memberId)
+                .orElseThrow(() -> new NotFoundException(MemoryErrorType.NOT_FOUND));
     }
 
     @Override

--- a/module-domain/src/main/java/com/depromeet/report/domain/ReportReasonCode.java
+++ b/module-domain/src/main/java/com/depromeet/report/domain/ReportReasonCode.java
@@ -1,0 +1,30 @@
+package com.depromeet.report.domain;
+
+import com.depromeet.converter.AbstractCodedEnumConverter;
+import com.depromeet.converter.CodedEnum;
+
+public enum ReportReasonCode implements CodedEnum<String> {
+    REPORT_REASON_1("스팸, 광고"),
+    REPORT_REASON_2("폭력적인 발언"),
+    REPORT_REASON_3("음란성, 선정 내용"),
+    REPORT_REASON_4("개인정보 노출"),
+    REPORT_REASON_5("주제와 무관");
+
+    private String value;
+
+    ReportReasonCode(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return this.value;
+    }
+
+    @jakarta.persistence.Converter(autoApply = true)
+    static class Converter extends AbstractCodedEnumConverter<ReportReasonCode, String> {
+        public Converter() {
+            super(ReportReasonCode.class);
+        }
+    }
+}

--- a/module-domain/src/main/java/com/depromeet/report/port/in/command/CreateReportCommand.java
+++ b/module-domain/src/main/java/com/depromeet/report/port/in/command/CreateReportCommand.java
@@ -1,0 +1,13 @@
+package com.depromeet.report.port.in.command;
+
+import com.depromeet.image.domain.Image;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
+import com.depromeet.report.domain.ReportReasonCode;
+import java.util.List;
+
+public record CreateReportCommand(
+        MemberIdAndNickname member,
+        MemoryIdAndDiaryAndMember reportMemory,
+        List<Image> images,
+        ReportReasonCode reasonCode) {}

--- a/module-domain/src/main/java/com/depromeet/report/port/in/usecase/CreateReportUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/report/port/in/usecase/CreateReportUseCase.java
@@ -1,0 +1,7 @@
+package com.depromeet.report.port.in.usecase;
+
+import com.depromeet.report.port.in.command.CreateReportCommand;
+
+public interface CreateReportUseCase {
+    void save(CreateReportCommand command);
+}

--- a/module-domain/src/main/java/com/depromeet/report/port/out/persistence/ReportPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/report/port/out/persistence/ReportPersistencePort.java
@@ -1,0 +1,7 @@
+package com.depromeet.report.port.out.persistence;
+
+import com.depromeet.report.port.in.command.CreateReportCommand;
+
+public interface ReportPersistencePort {
+    void writeReportToSheet(CreateReportCommand command);
+}

--- a/module-domain/src/main/java/com/depromeet/report/service/ReportService.java
+++ b/module-domain/src/main/java/com/depromeet/report/service/ReportService.java
@@ -1,0 +1,18 @@
+package com.depromeet.report.service;
+
+import com.depromeet.report.port.in.command.CreateReportCommand;
+import com.depromeet.report.port.in.usecase.CreateReportUseCase;
+import com.depromeet.report.port.out.persistence.ReportPersistencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService implements CreateReportUseCase {
+    private final ReportPersistencePort reportPersistencePort;
+
+    @Override
+    public void save(CreateReportCommand command) {
+        reportPersistencePort.writeReportToSheet(command);
+    }
+}

--- a/module-domain/src/test/java/com/depromeet/mock/member/FakeMemberRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/member/FakeMemberRepository.java
@@ -2,6 +2,7 @@ package com.depromeet.mock.member;
 
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
@@ -121,5 +122,11 @@ public class FakeMemberRepository implements MemberPersistencePort {
                             save(member);
                             return member;
                         });
+    }
+
+    @Override
+    public Optional<MemberIdAndNickname> findIdAndNicknameById(Long memberId) {
+        return findById(memberId)
+                .map(item -> new MemberIdAndNickname(item.getId(), item.getNickname()));
     }
 }

--- a/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
@@ -1,7 +1,9 @@
 package com.depromeet.mock.memory;
 
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.vo.MemoryAndDetailId;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
 import com.depromeet.memory.port.out.persistence.MemoryPersistencePort;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -193,5 +195,18 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     @Override
     public void deleteById(Long memoryId) {
         data.removeIf(item -> item.getId().equals(memoryId));
+    }
+
+    @Override
+    public Optional<MemoryIdAndDiaryAndMember> findIdAndNicknameById(Long memberId) {
+        return findById(memberId)
+                .map(
+                        item ->
+                                new MemoryIdAndDiaryAndMember(
+                                        item.getId(),
+                                        item.getDiary(),
+                                        new MemberIdAndNickname(
+                                                item.getMember().getId(),
+                                                item.getMember().getNickname())));
     }
 }

--- a/module-independent/src/main/java/com/depromeet/type/report/ReportErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/report/ReportErrorType.java
@@ -1,0 +1,25 @@
+package com.depromeet.type.report;
+
+import com.depromeet.type.ErrorType;
+
+public enum ReportErrorType implements ErrorType {
+    CANNOT_REPORT_OWN_MEMORY("REPORT_1", "자신의 기록을 신고할 수 없습니다");
+
+    private final String code;
+    private final String message;
+
+    ReportErrorType(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/module-independent/src/main/java/com/depromeet/type/report/ReportSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/report/ReportSuccessType.java
@@ -1,0 +1,25 @@
+package com.depromeet.type.report;
+
+import com.depromeet.type.SuccessType;
+
+public enum ReportSuccessType implements SuccessType {
+    POST_RESULT_SUCCESS("REPORT_1", "신고 사유 등록에 성공하였습니다");
+
+    private final String code;
+    private final String message;
+
+    ReportSuccessType(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/SpreadSheetProperties.java
+++ b/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/config/SpreadSheetProperties.java
@@ -4,4 +4,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "google.sheet")
 public record SpreadSheetProperties(
-        String credentialsFilePath, String applicationName, String sheetId, String range) {}
+        String credentialsFilePath,
+        String applicationName,
+        String sheetId,
+        String range,
+        String reportApplicationName,
+        String reportSheetId,
+        String reportRange) {}

--- a/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/spreadsheet/GoogleSheetManager.java
+++ b/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/spreadsheet/GoogleSheetManager.java
@@ -135,9 +135,7 @@ public class GoogleSheetManager implements WithdrawalReasonPort, ReportPersisten
     }
 
     private static String getDateTimeNow() {
-        String date =
-                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-        return date;
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 
     private String getImagesUrl(List<Image> images) {

--- a/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/spreadsheet/GoogleSheetManager.java
+++ b/module-infrastructure/google-spreadsheet/src/main/java/com/depromeet/spreadsheet/GoogleSheetManager.java
@@ -4,6 +4,9 @@ import static com.depromeet.type.withdrawal.WithdrawalReasonErrorType.FAILED_TO_
 
 import com.depromeet.config.SpreadSheetProperties;
 import com.depromeet.exception.InternalServerException;
+import com.depromeet.image.domain.Image;
+import com.depromeet.report.port.in.command.CreateReportCommand;
+import com.depromeet.report.port.out.persistence.ReportPersistencePort;
 import com.depromeet.withdrawal.domain.ReasonType;
 import com.depromeet.withdrawal.port.out.persistence.WithdrawalReasonPort;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
@@ -25,21 +28,25 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class GoogleSheetManager implements WithdrawalReasonPort {
+public class GoogleSheetManager implements WithdrawalReasonPort, ReportPersistencePort {
     private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
     private static final List<String> SCOPES = Collections.singletonList(SheetsScopes.SPREADSHEETS);
 
     private final SpreadSheetProperties spreadSheetProperties;
 
+    @Value("${cloud-front.domain}")
+    private String domain;
+
     @Override
     public void writeToSheet(ReasonType reasonType, String feedback) {
         try {
-            Sheets sheet = getSheetService();
+            Sheets sheet = getSheetService(spreadSheetProperties.applicationName());
             List<List<Object>> data = getData(reasonType, feedback);
             ValueRange valueRange = new ValueRange().setValues(data);
 
@@ -60,7 +67,8 @@ public class GoogleSheetManager implements WithdrawalReasonPort {
         }
     }
 
-    private Sheets getSheetService() throws IOException, GeneralSecurityException {
+    private Sheets getSheetService(String sheetApplicationName)
+            throws IOException, GeneralSecurityException {
         GoogleCredentials googleCredentials =
                 GoogleCredentials.fromStream(
                                 new FileInputStream(spreadSheetProperties.credentialsFilePath()))
@@ -69,17 +77,75 @@ public class GoogleSheetManager implements WithdrawalReasonPort {
                         GoogleNetHttpTransport.newTrustedTransport(),
                         JSON_FACTORY,
                         new HttpCredentialsAdapter(googleCredentials))
-                .setApplicationName(spreadSheetProperties.applicationName())
+                .setApplicationName(sheetApplicationName)
                 .build();
     }
 
     private List<List<Object>> getData(ReasonType reasonType, String feedback) {
-        String date =
-                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        String date = getDateTimeNow();
         feedback = feedback != null ? feedback : "";
 
         List<List<Object>> data = new ArrayList<>();
         data.add(List.of(reasonType.getCode(), reasonType.getReason(), feedback, date));
         return data;
+    }
+
+    @Override
+    public void writeReportToSheet(CreateReportCommand command) {
+        try {
+            Sheets sheet = getSheetService(spreadSheetProperties.reportApplicationName());
+            List<List<Object>> data = getReportData(command);
+            ValueRange valueRange = new ValueRange().setValues(data);
+
+            AppendValuesResponse appendResult =
+                    sheet.spreadsheets()
+                            .values()
+                            .append(
+                                    spreadSheetProperties.reportSheetId(),
+                                    spreadSheetProperties.reportRange(),
+                                    valueRange)
+                            .setValueInputOption("RAW")
+                            .setInsertDataOption("INSERT_ROWS")
+                            .setIncludeValuesInResponse(true)
+                            .execute();
+        } catch (Exception e) {
+            log.error("Error writing to sheet", e);
+            throw new InternalServerException(FAILED_TO_INSERT_DATA_TO_SPREADSHEET);
+        }
+    }
+
+    private List<List<Object>> getReportData(CreateReportCommand command) {
+        String date = getDateTimeNow();
+        String diary = command.reportMemory().diary() == null ? "" : command.reportMemory().diary();
+
+        List<List<Object>> data = new ArrayList<>();
+        data.add(
+                List.of(
+                        command.member().id(),
+                        command.member().nickname(),
+                        command.reportMemory().member().id(),
+                        command.reportMemory().member().nickname(),
+                        command.reportMemory().id(),
+                        getImagesUrl(command.images()),
+                        diary,
+                        command.reasonCode().name(),
+                        command.reasonCode().getValue(),
+                        date));
+        return data;
+    }
+
+    private static String getDateTimeNow() {
+        String date =
+                LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        return date;
+    }
+
+    private String getImagesUrl(List<Image> images) {
+        return images.isEmpty()
+                ? ""
+                : images.stream()
+                        .map(image -> domain + "/" + image.getImageName())
+                        .toList()
+                        .toString();
     }
 }

--- a/module-infrastructure/google-spreadsheet/src/main/resources/application-spreadsheet.yml
+++ b/module-infrastructure/google-spreadsheet/src/main/resources/application-spreadsheet.yml
@@ -9,3 +9,6 @@ google:
     application-name: ${GOOGLE_SHEET_APPLICATION_NAME}
     sheet-id: ${GOOGLE_SHEET_ID}
     range: ${GOOGLE_SHEET_RANGE}
+    report-application-name: ${GOOGLE_SHEET_REPORT_APPLICATION_NAME}
+    report-sheet-id: ${GOOGLE_SHEET_REPORT_ID}
+    report-range: ${GOOGLE_SHEET_REPORT_RANGE}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
@@ -3,12 +3,14 @@ package com.depromeet.member.repository;
 import com.depromeet.friend.entity.QFriendEntity;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.member.domain.vo.MemberSearchInfo;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.entity.MemberEntity;
 import com.depromeet.member.entity.QMemberEntity;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -148,6 +150,21 @@ public class MemberRepository implements MemberPersistencePort {
         return memberJpaRepository
                 .findById(memberId)
                 .map(memberEntity -> memberEntity.updateProfileImageUrl(profileImageUrl).toModel());
+    }
+
+    @Override
+    public Optional<MemberIdAndNickname> findIdAndNicknameById(Long memberId) {
+        Tuple result =
+                queryFactory
+                        .select(member.id, member.nickname)
+                        .from(member)
+                        .where(member.id.eq(memberId))
+                        .fetchOne();
+        if (result == null) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                new MemberIdAndNickname(result.get(0, Long.class), result.get(1, String.class)));
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -6,8 +6,10 @@ import static com.depromeet.memory.entity.QMemoryDetailEntity.memoryDetailEntity
 import static com.depromeet.memory.entity.QStrokeEntity.strokeEntity;
 import static com.depromeet.pool.entity.QPoolEntity.poolEntity;
 
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.memory.domain.Memory;
 import com.depromeet.memory.domain.vo.MemoryAndDetailId;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
 import com.depromeet.memory.entity.MemoryEntity;
 import com.depromeet.memory.entity.QMemoryEntity;
 import com.depromeet.memory.port.out.persistence.MemoryPersistencePort;
@@ -214,6 +216,25 @@ public class MemoryRepository implements MemoryPersistencePort {
     @Override
     public void deleteById(Long memoryId) {
         memoryJpaRepository.deleteById(memoryId);
+    }
+
+    @Override
+    public Optional<MemoryIdAndDiaryAndMember> findIdAndNicknameById(Long memoryId) {
+        Tuple result =
+                queryFactory
+                        .select(memory.id, memory.diary, memory.member.id, memory.member.nickname)
+                        .from(memory)
+                        .join(memory.member, memberEntity)
+                        .where(memory.id.eq(memoryId))
+                        .fetchOne();
+        if (result == null) {
+            return Optional.empty();
+        }
+        MemberIdAndNickname member =
+                new MemberIdAndNickname(result.get(2, Long.class), result.get(3, String.class));
+        return Optional.of(
+                new MemoryIdAndDiaryAndMember(
+                        result.get(0, Long.class), result.get(1, String.class), member));
     }
 
     private BooleanExpression loeRecordAt(LocalDate recordAt) {

--- a/module-presentation/src/main/java/com/depromeet/report/api/ReportApi.java
+++ b/module-presentation/src/main/java/com/depromeet/report/api/ReportApi.java
@@ -1,0 +1,14 @@
+package com.depromeet.report.api;
+
+import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.member.annotation.LoginMember;
+import com.depromeet.report.dto.request.ReportRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "기록 신고(Report)")
+public interface ReportApi {
+    @Operation(description = "기록 신고 제출")
+    ApiResponse<?> create(@LoginMember Long memberId, @RequestBody ReportRequest request);
+}

--- a/module-presentation/src/main/java/com/depromeet/report/api/ReportController.java
+++ b/module-presentation/src/main/java/com/depromeet/report/api/ReportController.java
@@ -1,0 +1,27 @@
+package com.depromeet.report.api;
+
+import com.depromeet.config.Logging;
+import com.depromeet.dto.response.ApiResponse;
+import com.depromeet.member.annotation.LoginMember;
+import com.depromeet.report.dto.request.ReportRequest;
+import com.depromeet.report.facade.ReportFacade;
+import com.depromeet.type.report.ReportSuccessType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/report")
+public class ReportController implements ReportApi {
+    private final ReportFacade reportFacade;
+
+    @PostMapping
+    @Logging(item = "Report", action = "POST")
+    public ApiResponse<?> create(@LoginMember Long memberId, @RequestBody ReportRequest request) {
+        reportFacade.save(memberId, request);
+        return ApiResponse.success(ReportSuccessType.POST_RESULT_SUCCESS);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/report/api/ReportController.java
+++ b/module-presentation/src/main/java/com/depromeet/report/api/ReportController.java
@@ -6,6 +6,7 @@ import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.report.dto.request.ReportRequest;
 import com.depromeet.report.facade.ReportFacade;
 import com.depromeet.type.report.ReportSuccessType;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,8 @@ public class ReportController implements ReportApi {
 
     @PostMapping
     @Logging(item = "Report", action = "POST")
-    public ApiResponse<?> create(@LoginMember Long memberId, @RequestBody ReportRequest request) {
+    public ApiResponse<?> create(
+            @LoginMember Long memberId, @Valid @RequestBody ReportRequest request) {
         reportFacade.save(memberId, request);
         return ApiResponse.success(ReportSuccessType.POST_RESULT_SUCCESS);
     }

--- a/module-presentation/src/main/java/com/depromeet/report/dto/request/ReportRequest.java
+++ b/module-presentation/src/main/java/com/depromeet/report/dto/request/ReportRequest.java
@@ -1,0 +1,19 @@
+package com.depromeet.report.dto.request;
+
+import com.depromeet.report.domain.ReportReasonCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record ReportRequest(
+        @NotNull
+                @Schema(
+                        description = "신고할 기록 id",
+                        example = "1",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                Long memoryId,
+        @NotNull
+                @Schema(
+                        description = "신고 사유 code",
+                        example = "REPORT_REASON_1",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                ReportReasonCode reasonCode) {}

--- a/module-presentation/src/main/java/com/depromeet/report/facade/ReportFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/report/facade/ReportFacade.java
@@ -1,5 +1,6 @@
 package com.depromeet.report.facade;
 
+import com.depromeet.exception.BadRequestException;
 import com.depromeet.image.domain.Image;
 import com.depromeet.image.port.in.ImageGetUseCase;
 import com.depromeet.member.domain.vo.MemberIdAndNickname;
@@ -10,6 +11,7 @@ import com.depromeet.report.dto.request.ReportRequest;
 import com.depromeet.report.mapper.ReportMapper;
 import com.depromeet.report.port.in.command.CreateReportCommand;
 import com.depromeet.report.port.in.usecase.CreateReportUseCase;
+import com.depromeet.type.report.ReportErrorType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,6 +30,9 @@ public class ReportFacade {
         MemberIdAndNickname member = memberUseCase.findIdAndNicknameById(memberId);
         MemoryIdAndDiaryAndMember reportMemory =
                 getMemoryUseCase.findIdAndNicknameById(request.memoryId());
+        if (memberId.equals(reportMemory.member().id())) {
+            throw new BadRequestException(ReportErrorType.CANNOT_REPORT_OWN_MEMORY);
+        }
         List<Image> images = imageGetUseCase.findImagesByMemoryId(reportMemory.id());
         CreateReportCommand command =
                 ReportMapper.toCommand(member, reportMemory, images, request.reasonCode());

--- a/module-presentation/src/main/java/com/depromeet/report/facade/ReportFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/report/facade/ReportFacade.java
@@ -1,0 +1,36 @@
+package com.depromeet.report.facade;
+
+import com.depromeet.image.domain.Image;
+import com.depromeet.image.port.in.ImageGetUseCase;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
+import com.depromeet.member.port.in.usecase.MemberUseCase;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
+import com.depromeet.memory.port.in.usecase.GetMemoryUseCase;
+import com.depromeet.report.dto.request.ReportRequest;
+import com.depromeet.report.mapper.ReportMapper;
+import com.depromeet.report.port.in.command.CreateReportCommand;
+import com.depromeet.report.port.in.usecase.CreateReportUseCase;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportFacade {
+    private final MemberUseCase memberUseCase;
+    private final ImageGetUseCase imageGetUseCase;
+    private final GetMemoryUseCase getMemoryUseCase;
+    private final CreateReportUseCase createReportUseCase;
+
+    @Transactional
+    public void save(Long memberId, ReportRequest request) {
+        MemberIdAndNickname member = memberUseCase.findIdAndNicknameById(memberId);
+        MemoryIdAndDiaryAndMember reportMemory =
+                getMemoryUseCase.findIdAndNicknameById(request.memoryId());
+        List<Image> images = imageGetUseCase.findImagesByMemoryId(reportMemory.id());
+        CreateReportCommand command =
+                ReportMapper.toCommand(member, reportMemory, images, request.reasonCode());
+        createReportUseCase.save(command);
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/report/mapper/ReportMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/report/mapper/ReportMapper.java
@@ -1,0 +1,18 @@
+package com.depromeet.report.mapper;
+
+import com.depromeet.image.domain.Image;
+import com.depromeet.member.domain.vo.MemberIdAndNickname;
+import com.depromeet.memory.domain.vo.MemoryIdAndDiaryAndMember;
+import com.depromeet.report.domain.ReportReasonCode;
+import com.depromeet.report.port.in.command.CreateReportCommand;
+import java.util.List;
+
+public class ReportMapper {
+    public static CreateReportCommand toCommand(
+            MemberIdAndNickname member,
+            MemoryIdAndDiaryAndMember reportMemory,
+            List<Image> images,
+            ReportReasonCode reasonCode) {
+        return new CreateReportCommand(member, reportMemory, images, reasonCode);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈

- close #378

## 📌 작업 내용 및 특이사항
- 기록을 신고할 수 있는 기능을 구현하였습니다.
- 신고하게 되면 구글 스프레드시트에 데이터가 저장됩니다.
<img width="1441" alt="Screenshot 2024-09-07 at 01 07 39" src="https://github.com/user-attachments/assets/5024cf69-bc2a-4e56-9ca9-63bd385a598c">
<img width="1442" alt="Screenshot 2024-09-07 at 01 14 07" src="https://github.com/user-attachments/assets/1b4a8435-0069-45ba-80ea-251a1ac7adac">

- 쿼리는 총 세 번 발생합니다.
<details>
<summary>펼치기</summary>

```
Hibernate: 
    select
        me1_0.member_id,
        me1_0.nickname 
    from
        member_entity me1_0 
    where
        me1_0.member_id=?
Hibernate: 
    select
        me1_0.memory_id,
        me1_0.diary,
        me1_0.member_id,
        m1_0.nickname 
    from
        memory_entity me1_0 
    join
        member_entity m1_0 
            on m1_0.member_id=me1_0.member_id 
    where
        me1_0.memory_id=?
Hibernate: 
    select
        ie1_0.image_id,
        ie1_0.image_name,
        ie1_0.upload_status,
        ie1_0.image_url,
        ie1_0.memory_id,
        ie1_0.origin_image_name 
    from
        image_entity ie1_0 
    where
        ie1_0.memory_id=? 
        and ie1_0.upload_status=?
```
</details>

## 📝 참고사항
- 신고 성공
<img width="829" alt="Screenshot 2024-09-07 at 01 14 44" src="https://github.com/user-attachments/assets/054acece-9238-4fc5-97db-1f063f68ce13">

- 자신의 기록 신고 실패
<img width="845" alt="Screenshot 2024-09-07 at 01 13 46" src="https://github.com/user-attachments/assets/fb0b3730-ee6e-4e41-8b86-ef20efb45464">

- 신고 유형 실패
<img width="853" alt="Screenshot 2024-09-07 at 01 09 16" src="https://github.com/user-attachments/assets/a4dd5eae-088f-4600-8e2f-6e76da99509c">