### PR TITLE
feat: 차단한 사용자 조회 API 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/blacklist/domain/vo/BlacklistPage.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/domain/vo/BlacklistPage.java
@@ -1,0 +1,10 @@
+package com.depromeet.blacklist.domain.vo;
+
+import com.depromeet.member.domain.Member;
+import java.util.List;
+
+public record BlacklistPage(List<Member> blackMembers, boolean hasNext, Long cursorId) {
+    public static BlacklistPage of(List<Member> blackMembers, boolean hasNext, Long nextCursorId) {
+        return new BlacklistPage(blackMembers, hasNext, nextCursorId);
+    }
+}

--- a/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistQueryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistQueryUseCase.java
@@ -1,5 +1,9 @@
 package com.depromeet.blacklist.port.in.usecase;
 
+import com.depromeet.blacklist.domain.vo.BlacklistPage;
+
 public interface BlacklistQueryUseCase {
     boolean checkBlackMember(Long memberId, Long blackMemberId);
+
+    BlacklistPage getBlackMembers(Long memberId, Long cursorId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
@@ -1,6 +1,8 @@
 package com.depromeet.blacklist.port.out.persistence;
 
 import com.depromeet.blacklist.domain.Blacklist;
+import com.depromeet.member.domain.Member;
+import java.util.List;
 
 public interface BlacklistPersistencePort {
     Blacklist save(Blacklist blacklist);
@@ -8,4 +10,6 @@ public interface BlacklistPersistencePort {
     boolean existsByMemberIdAndBlackMemberId(Long memberId, Long blackMemberId);
 
     void unblackMember(Long memberId, Long blackMemberId);
+
+    List<Member> findBlackMembers(Long memberId, Long cursorId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
@@ -1,10 +1,12 @@
 package com.depromeet.blacklist.service;
 
 import com.depromeet.blacklist.domain.Blacklist;
+import com.depromeet.blacklist.domain.vo.BlacklistPage;
 import com.depromeet.blacklist.port.in.usecase.BlacklistCommandUseCase;
 import com.depromeet.blacklist.port.in.usecase.BlacklistQueryUseCase;
 import com.depromeet.blacklist.port.out.persistence.BlacklistPersistencePort;
 import com.depromeet.member.domain.Member;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,5 +36,18 @@ public class BlacklistService implements BlacklistQueryUseCase, BlacklistCommand
     @Override
     public boolean checkBlackMember(Long memberId, Long blackMemberId) {
         return blacklistPersistencePort.existsByMemberIdAndBlackMemberId(memberId, blackMemberId);
+    }
+
+    @Override
+    public BlacklistPage getBlackMembers(Long memberId, Long cursorId) {
+        List<Member> blackMembers = blacklistPersistencePort.findBlackMembers(memberId, cursorId);
+        boolean hasNext = false;
+        Long nextCursorId = null;
+        if (blackMembers != null && blackMembers.size() > 10) {
+            hasNext = true;
+            Member member = blackMembers.removeLast();
+            nextCursorId = member.getId();
+        }
+        return BlacklistPage.of(blackMembers, hasNext, nextCursorId);
     }
 }

--- a/module-domain/src/main/java/com/depromeet/member/domain/Member.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/Member.java
@@ -43,6 +43,13 @@ public class Member {
         this.lastViewedFollowingLogAt = lastViewedFollowingLogAt;
     }
 
+    public Member(Long id, String nickname, String profileImageUrl, String introduction) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.introduction = introduction;
+    }
+
     public Member updateGoal(Integer goal) {
         this.goal = goal;
         return this;

--- a/module-independent/src/main/java/com/depromeet/type/blacklist/BlacklistErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/blacklist/BlacklistErrorType.java
@@ -3,7 +3,8 @@ package com.depromeet.type.blacklist;
 import com.depromeet.type.ErrorType;
 
 public enum BlacklistErrorType implements ErrorType {
-    ALREADY_BLACKED("BLACK_1", "이미 차단한 사용자입니다");
+    ALREADY_BLACKED("BLACK_1", "이미 차단한 사용자입니다"),
+    CANNOT_BLACK_MYSELF("BLACK_2", "자기 자신을 차단할 수 없습니다");
 
     private final String code;
     private final String message;

--- a/module-independent/src/main/java/com/depromeet/type/blacklist/BlacklistSuccessType.java
+++ b/module-independent/src/main/java/com/depromeet/type/blacklist/BlacklistSuccessType.java
@@ -4,7 +4,8 @@ import com.depromeet.type.SuccessType;
 
 public enum BlacklistSuccessType implements SuccessType {
     BLACK_MEMBER_SUCCESS("BLACK_1", "사용자를 성공적으로 차단하였습니다"),
-    UNBLACK_MEMBER_SUCCESS("BLACK_2", "사용자를 차단 해제하였습니다");
+    UNBLACK_MEMBER_SUCCESS("BLACK_2", "사용자를 차단 해제하였습니다"),
+    GET_BLACK_MEMBERS_SUCCESS("BLACK_3", "사용자의 차단 목록을 성공적으로 조회하였습니다");
 
     private final String code;
     private final String message;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistRepository.java
@@ -1,14 +1,23 @@
 package com.depromeet.blacklist.repository;
 
+import static com.depromeet.blacklist.entity.QBlacklistEntity.*;
+
 import com.depromeet.blacklist.domain.Blacklist;
 import com.depromeet.blacklist.entity.BlacklistEntity;
 import com.depromeet.blacklist.port.out.persistence.BlacklistPersistencePort;
+import com.depromeet.member.domain.Member;
+import com.depromeet.member.entity.QMemberEntity;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class BlacklistRepository implements BlacklistPersistencePort {
+    private final JPAQueryFactory queryFactory;
     private final BlacklistJpaRepository blacklistJpaRepository;
 
     @Override
@@ -24,5 +33,40 @@ public class BlacklistRepository implements BlacklistPersistencePort {
     @Override
     public void unblackMember(Long memberId, Long blackMemberId) {
         blacklistJpaRepository.deleteByMemberIdAndBlackMemberId(memberId, blackMemberId);
+    }
+
+    @Override
+    public List<Member> findBlackMembers(Long memberId, Long cursorId) {
+        QMemberEntity member = new QMemberEntity("member"); // 첫 번째 별칭 "member"
+        QMemberEntity blackMember = new QMemberEntity("blackMember");
+
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                Member.class, // 원하는 DTO나 엔티티 클래스 지정
+                                blacklistEntity.blackMember.id,
+                                blacklistEntity.blackMember.nickname,
+                                blacklistEntity.blackMember.profileImageUrl,
+                                blacklistEntity.blackMember.introduction))
+                .from(blacklistEntity)
+                .join(blacklistEntity.blackMember, blackMember)
+                .where(memberEq(memberId), blacklistIdLoe(cursorId))
+                .orderBy(blacklistEntity.blackMember.id.desc())
+                .limit(11)
+                .fetch();
+    }
+
+    private static BooleanExpression memberEq(Long memberId) {
+        if (memberId == null) {
+            return null;
+        }
+        return blacklistEntity.member.id.eq(memberId);
+    }
+
+    private BooleanExpression blacklistIdLoe(Long cursorId) {
+        if (cursorId == null) {
+            return null;
+        }
+        return blacklistEntity.blackMember.id.loe(cursorId);
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/entity/MemberEntity.java
@@ -69,6 +69,13 @@ public class MemberEntity {
         this.lastViewedFollowingLogAt = lastViewedFollowingLogAt;
     }
 
+    public MemberEntity(Long id, String nickname, String profileImageUrl, String introduction) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.introduction = introduction;
+    }
+
     @PrePersist
     public void prePersist() {
         this.goal = 1000;

--- a/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistApi.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistApi.java
@@ -1,6 +1,7 @@
 package com.depromeet.blacklist.api;
 
 import com.depromeet.blacklist.dto.request.BlackMemberRequest;
+import com.depromeet.blacklist.dto.response.BlackMemberResponse;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "차단(Blacklist)")
 public interface BlacklistApi {
@@ -18,4 +20,9 @@ public interface BlacklistApi {
     @Operation(summary = "사용자 차단 해제")
     ApiResponse<?> unblackMember(
             @LoginMember Long memberId, @PathVariable("blackMemberId") Long blackMemberId);
+
+    @Operation(summary = "사용자 차단 목록 조회")
+    ApiResponse<BlackMemberResponse> getBlackMembers(
+            @LoginMember Long memberId,
+            @RequestParam(value = "cursorId", required = false) Long cursorId);
 }

--- a/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistController.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistController.java
@@ -1,6 +1,7 @@
 package com.depromeet.blacklist.api;
 
 import com.depromeet.blacklist.dto.request.BlackMemberRequest;
+import com.depromeet.blacklist.dto.response.BlackMemberResponse;
 import com.depromeet.blacklist.facade.BlacklistFacade;
 import com.depromeet.config.Logging;
 import com.depromeet.dto.response.ApiResponse;
@@ -9,10 +10,12 @@ import com.depromeet.type.blacklist.BlacklistSuccessType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -35,5 +38,14 @@ public class BlacklistController implements BlacklistApi {
             @LoginMember Long memberId, @PathVariable("blackMemberId") Long blackMemberId) {
         blacklistFacade.unblackMember(memberId, blackMemberId);
         return ApiResponse.success(BlacklistSuccessType.UNBLACK_MEMBER_SUCCESS);
+    }
+
+    @GetMapping("/black")
+    @Logging(item = "Blacklist", action = "GET")
+    public ApiResponse<BlackMemberResponse> getBlackMembers(
+            @LoginMember Long memberId,
+            @RequestParam(value = "cursorId", required = false) Long cursorId) {
+        BlackMemberResponse response = blacklistFacade.getBlackMembers(memberId, cursorId);
+        return ApiResponse.success(BlacklistSuccessType.GET_BLACK_MEMBERS_SUCCESS, response);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/blacklist/dto/response/BlackMemberDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/dto/response/BlackMemberDetailResponse.java
@@ -34,23 +34,8 @@ public record BlackMemberDetailResponse(
                                 new BlackMemberDetailResponse(
                                         member.getId(),
                                         member.getNickname(),
-                                        getProfileImageUrl(member, domain),
+                                        member.getProfileImageUrl(domain),
                                         member.getIntroduction()))
                 .toList();
-    }
-
-    private static String getProfileImageUrl(Member member, String domain) {
-        if (member.getProfileImageUrl() == null) {
-            return null;
-        }
-        if (isDefaultImage(member)) {
-            return member.getProfileImageUrl();
-        }
-        return domain + "/" + member.getProfileImageUrl();
-    }
-
-    private static boolean isDefaultImage(Member member) {
-        String url = member.getProfileImageUrl();
-        return url.equals("1") || url.equals("2") || url.equals("3") || url.equals("4");
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/blacklist/dto/response/BlackMemberDetailResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/dto/response/BlackMemberDetailResponse.java
@@ -1,0 +1,56 @@
+package com.depromeet.blacklist.dto.response;
+
+import com.depromeet.member.domain.Member;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BlackMemberDetailResponse(
+        @Schema(
+                        description = "차단한 유저 아이디",
+                        example = "2",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                Long memberId,
+        @Schema(
+                        description = "차단한 유저 닉네임",
+                        example = "스탑제로",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                String nickname,
+        @Schema(
+                        description = "차단한 유저 프로필 이미지",
+                        example = "https://example.com/image.jpg OR 기본 이미지(1,2,3,4)",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                String profileImageUrl,
+        @Schema(
+                        description = "차단한 유저 소개",
+                        example = "안녕하세요",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                String introduction) {
+    public static List<BlackMemberDetailResponse> of(List<Member> blackMembers, String domain) {
+        return blackMembers.stream()
+                .map(
+                        member ->
+                                new BlackMemberDetailResponse(
+                                        member.getId(),
+                                        member.getNickname(),
+                                        getProfileImageUrl(member, domain),
+                                        member.getIntroduction()))
+                .toList();
+    }
+
+    private static String getProfileImageUrl(Member member, String domain) {
+        if (member.getProfileImageUrl() == null) {
+            return null;
+        }
+        if (isDefaultImage(member)) {
+            return member.getProfileImageUrl();
+        }
+        return domain + "/" + member.getProfileImageUrl();
+    }
+
+    private static boolean isDefaultImage(Member member) {
+        String url = member.getProfileImageUrl();
+        return url.equals("1") || url.equals("2") || url.equals("3") || url.equals("4");
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/blacklist/dto/response/BlackMemberResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/dto/response/BlackMemberResponse.java
@@ -1,0 +1,28 @@
+package com.depromeet.blacklist.dto.response;
+
+import com.depromeet.blacklist.domain.vo.BlacklistPage;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BlackMemberResponse(
+        @Schema(description = "차단한 유저 리스트", requiredMode = Schema.RequiredMode.REQUIRED)
+                List<BlackMemberDetailResponse> blackMembers,
+        @Schema(
+                        description = "다음 페이지가 존재하는지 여부",
+                        example = "true",
+                        requiredMode = Schema.RequiredMode.REQUIRED)
+                boolean hasNext,
+        @Schema(
+                        description = "다음 페이지 검색 커서 ID(hasNext가 false일 시 null)",
+                        example = "11",
+                        requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+                Long cursorId) {
+    public static BlackMemberResponse of(BlacklistPage page, String domain) {
+        return new BlackMemberResponse(
+                BlackMemberDetailResponse.of(page.blackMembers(), domain),
+                page.hasNext(),
+                page.cursorId());
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
@@ -1,11 +1,14 @@
 package com.depromeet.blacklist.facade;
 
+import com.depromeet.blacklist.domain.vo.BlacklistPage;
 import com.depromeet.blacklist.dto.request.BlackMemberRequest;
+import com.depromeet.blacklist.dto.response.BlackMemberResponse;
 import com.depromeet.blacklist.port.in.usecase.BlacklistCommandUseCase;
 import com.depromeet.blacklist.port.in.usecase.BlacklistQueryUseCase;
 import com.depromeet.exception.BadRequestException;
 import com.depromeet.type.blacklist.BlacklistErrorType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class BlacklistFacade {
     private final BlacklistQueryUseCase blacklistQueryUseCase;
     private final BlacklistCommandUseCase blacklistCommandUseCase;
+
+    @Value("${cloud-front.domain}")
+    private String domain;
 
     public void blackMember(Long memberId, BlackMemberRequest request) {
         Long blackMemberId = request.blackMemberId();
@@ -28,5 +34,11 @@ public class BlacklistFacade {
 
     public void unblackMember(Long memberId, Long blackMemberId) {
         blacklistCommandUseCase.unblackMember(memberId, blackMemberId);
+    }
+
+    @Transactional(readOnly = true)
+    public BlackMemberResponse getBlackMembers(Long memberId, Long cursorId) {
+        BlacklistPage page = blacklistQueryUseCase.getBlackMembers(memberId, cursorId);
+        return BlackMemberResponse.of(page, domain);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
@@ -24,6 +24,10 @@ public class BlacklistFacade {
 
     public void blackMember(Long memberId, BlackMemberRequest request) {
         Long blackMemberId = request.blackMemberId();
+        if (memberId.equals(blackMemberId)) {
+            throw new BadRequestException(BlacklistErrorType.CANNOT_BLACK_MYSELF);
+        }
+
         boolean isAlreadyBlacked = blacklistQueryUseCase.checkBlackMember(memberId, blackMemberId);
         if (isAlreadyBlacked) {
             throw new BadRequestException(BlacklistErrorType.ALREADY_BLACKED);


### PR DESCRIPTION
## 🌱 관련 이슈

- close #385 

## 📌 작업 내용 및 특이사항
- 차단한 사용자 조회 API를 구현하였습니다.

## 📝 참고사항
<img width="897" alt="image" src="https://github.com/user-attachments/assets/3444dcc3-e651-4c59-8d43-bb79892b328f">
