### PR TITLE
feat: 유저 검색 시 차단한 사람/본인을 차단한 사람 안 보이게 하는 기능 추가

### DIFF
--- a/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberSearchInfo.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberSearchInfo.java
@@ -12,20 +12,14 @@ public class MemberSearchInfo {
     private String nickname;
     private String profileImageUrl;
     private String introduction;
-    private boolean hasFollowed;
 
     @Builder
     public MemberSearchInfo(
-            Long memberId,
-            String nickname,
-            String profileImageUrl,
-            String introduction,
-            boolean hasFollowed) {
+            Long memberId, String nickname, String profileImageUrl, String introduction) {
         this.memberId = memberId;
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
         this.introduction = introduction;
-        this.hasFollowed = hasFollowed;
     }
 
     public String getProfileImageUrl(String profileImageOrigin) {

--- a/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberSearchPage.java
+++ b/module-domain/src/main/java/com/depromeet/member/domain/vo/MemberSearchPage.java
@@ -9,15 +9,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class MemberSearchPage {
     private List<MemberSearchInfo> members;
-    private int pageSize;
     private Long cursorId;
     private boolean hasNext;
 
     @Builder
-    public MemberSearchPage(
-            List<MemberSearchInfo> members, int pageSize, Long cursorId, boolean hasNext) {
+    public MemberSearchPage(List<MemberSearchInfo> members, Long cursorId, boolean hasNext) {
         this.members = members;
-        this.pageSize = pageSize;
         this.cursorId = cursorId;
         this.hasNext = hasNext;
     }

--- a/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/member/port/out/persistence/MemberPersistencePort.java
@@ -3,8 +3,9 @@ package com.depromeet.member.port.out.persistence;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.vo.MemberIdAndNickname;
-import com.depromeet.member.domain.vo.MemberSearchPage;
+import com.depromeet.member.domain.vo.MemberSearchInfo;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberPersistencePort {
@@ -24,7 +25,7 @@ public interface MemberPersistencePort {
 
     void deleteById(Long id);
 
-    MemberSearchPage searchByNameQuery(Long memberId, String nameQuery, Long cursorId);
+    List<MemberSearchInfo> searchByNameQuery(Long memberId, String nameQuery, Long cursorId);
 
     Optional<Member> updateLatestViewedFollowingLogAt(Long memberId);
 

--- a/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
+++ b/module-domain/src/main/java/com/depromeet/member/service/MemberService.java
@@ -8,6 +8,7 @@ import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.MemberRole;
 import com.depromeet.member.domain.vo.MemberIdAndNickname;
+import com.depromeet.member.domain.vo.MemberSearchInfo;
 import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.port.in.command.SocialMemberCommand;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
@@ -16,6 +17,8 @@ import com.depromeet.member.port.in.usecase.MemberUpdateUseCase;
 import com.depromeet.member.port.in.usecase.MemberUseCase;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import com.depromeet.type.member.MemberErrorType;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
@@ -62,7 +65,22 @@ public class MemberService implements MemberUseCase, GoalUpdateUseCase, MemberUp
 
     @Override
     public MemberSearchPage searchMemberByName(Long memberId, String nameQuery, Long cursorId) {
-        return memberPersistencePort.searchByNameQuery(memberId, nameQuery, cursorId);
+        List<MemberSearchInfo> memberSearchInfos =
+                memberPersistencePort.searchByNameQuery(memberId, nameQuery, cursorId);
+
+        boolean hasNext = false;
+        Long nextCursorId = null;
+        if (memberSearchInfos.size() > 10) {
+            memberSearchInfos = new ArrayList<>(memberSearchInfos);
+            memberSearchInfos.removeLast();
+            hasNext = true;
+            nextCursorId = memberSearchInfos.getLast().getMemberId();
+        }
+        return MemberSearchPage.builder()
+                .members(memberSearchInfos)
+                .cursorId(nextCursorId)
+                .hasNext(hasNext)
+                .build();
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/member/FakeMemberRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/member/FakeMemberRepository.java
@@ -3,7 +3,7 @@ package com.depromeet.mock.member;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.vo.MemberIdAndNickname;
-import com.depromeet.member.domain.vo.MemberSearchPage;
+import com.depromeet.member.domain.vo.MemberSearchInfo;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import java.util.ArrayList;
@@ -87,7 +87,8 @@ public class FakeMemberRepository implements MemberPersistencePort {
     }
 
     @Override
-    public MemberSearchPage searchByNameQuery(Long memberId, String nameQuery, Long cursorId) {
+    public List<MemberSearchInfo> searchByNameQuery(
+            Long memberId, String nameQuery, Long cursorId) {
         return null;
     }
 

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/member/repository/MemberRepository.java
@@ -1,29 +1,20 @@
 package com.depromeet.member.repository;
 
-import com.depromeet.friend.entity.QFriendEntity;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.vo.MemberIdAndNickname;
 import com.depromeet.member.domain.vo.MemberSearchInfo;
-import com.depromeet.member.domain.vo.MemberSearchPage;
 import com.depromeet.member.entity.MemberEntity;
 import com.depromeet.member.entity.QMemberEntity;
 import com.depromeet.member.port.in.command.UpdateMemberCommand;
 import com.depromeet.member.port.out.persistence.MemberPersistencePort;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -74,47 +65,21 @@ public class MemberRepository implements MemberPersistencePort {
     }
 
     @Override
-    public MemberSearchPage searchByNameQuery(Long memberId, String nameQuery, Long cursorId) {
-        QFriendEntity friend = QFriendEntity.friendEntity;
-
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
-
-        List<MemberSearchInfo> contents =
-                queryFactory
-                        .select(
-                                Projections.constructor(
-                                        MemberSearchInfo.class,
-                                        member.id.as("memberId"),
-                                        member.nickname.as("nickname"),
-                                        member.profileImageUrl.as("profileImageUrl"),
-                                        member.introduction.as("introduction"),
-                                        ExpressionUtils.as(
-                                                JPAExpressions.select(Expressions.constant(true))
-                                                        .from(friend)
-                                                        .where(
-                                                                friend.following.id.eq(member.id),
-                                                                friend.member.id.eq(memberId)),
-                                                "hasFollowed")))
-                        .from(member)
-                        .where(likeName(nameQuery), ltCursorId(cursorId))
-                        .limit(pageable.getPageSize() + 1)
-                        .orderBy(member.id.desc())
-                        .fetch();
-
-        boolean hasNext = false;
-        Long nextCursorId = null;
-        if (contents.size() > pageable.getPageSize()) {
-            contents = new ArrayList<>(contents);
-            contents.removeLast();
-            hasNext = true;
-            nextCursorId = contents.getLast().getMemberId();
-        }
-        return MemberSearchPage.builder()
-                .members(contents)
-                .pageSize(contents.size())
-                .cursorId(nextCursorId)
-                .hasNext(hasNext)
-                .build();
+    public List<MemberSearchInfo> searchByNameQuery(
+            Long memberId, String nameQuery, Long cursorId) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                MemberSearchInfo.class,
+                                member.id.as("memberId"),
+                                member.nickname.as("nickname"),
+                                member.profileImageUrl.as("profileImageUrl"),
+                                member.introduction.as("introduction")))
+                .from(member)
+                .where(likeName(nameQuery), ltCursorId(cursorId))
+                .limit(11)
+                .orderBy(member.id.desc())
+                .fetch();
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowApi.java
@@ -20,12 +20,14 @@ public interface FollowApi {
 
     @Operation(summary = "팔로잉 리스트 조회")
     ApiResponse<FollowSliceResponse<FollowingResponse>> findFollowingList(
+            @LoginMember Long requesterId,
             @Parameter(description = "팔로잉 리스트 조회할 대상의 member PK") @PathVariable(value = "memberId")
                     Long memberId,
             @RequestParam(value = "cursorId", required = false) Long cursorId);
 
     @Operation(summary = "팔로워 리스트 조회")
     ApiResponse<FollowSliceResponse<FollowerResponse>> findFollowerList(
+            @LoginMember Long requesterId,
             @Parameter(description = "팔로워 리스트 조회할 대상의 member PK") @PathVariable(value = "memberId")
                     Long memberId,
             @RequestParam(value = "cursorId", required = false) Long cursorId);

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
@@ -9,8 +9,10 @@ import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.type.friend.FollowSuccessType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/friend")
@@ -32,20 +34,22 @@ public class FollowController implements FollowApi {
     @GetMapping("/{memberId}/following")
     @Logging(item = "Follower/Following", action = "GET")
     public ApiResponse<FollowSliceResponse<FollowingResponse>> findFollowingList(
+            @LoginMember Long requesterId,
             @PathVariable(value = "memberId") Long memberId,
             @RequestParam(value = "cursorId", required = false) Long cursorId) {
         FollowSliceResponse<FollowingResponse> response =
-                followFacade.findFollowingList(memberId, cursorId);
+                followFacade.findFollowingList(memberId, requesterId, cursorId);
         return ApiResponse.success(FollowSuccessType.GET_FOLLOWINGS_SUCCESS, response);
     }
 
     @GetMapping("/{memberId}/follower")
     @Logging(item = "Follower/Following", action = "GET")
     public ApiResponse<FollowSliceResponse<FollowerResponse>> findFollowerList(
+            @LoginMember Long requesterId,
             @PathVariable(value = "memberId") Long memberId,
             @RequestParam(value = "cursorId", required = false) Long cursorId) {
         FollowSliceResponse<FollowerResponse> response =
-                followFacade.findFollowerList(memberId, cursorId);
+                followFacade.findFollowerList(memberId, requesterId, cursorId);
         return ApiResponse.success(FollowSuccessType.GET_FOLLOWERS_SUCCESS, response);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
@@ -42,7 +42,8 @@ public record FollowSliceResponse<T>(
     }
 
     public static FollowSliceResponse<FollowerResponse> toFollowerSliceResponses(
-            FollowSlice<Follower> followingSlice,
+            Long cursorId,
+            boolean hasNext,
             List<Follower> filteredFollowers,
             String profileImageOrigin) {
         List<FollowerResponse> followerResponses =
@@ -50,8 +51,8 @@ public record FollowSliceResponse<T>(
         return FollowSliceResponse.<FollowerResponse>builder()
                 .contents(followerResponses)
                 .pageSize(followerResponses.size())
-                .cursorId(followingSlice.getCursorId())
-                .hasNext(followingSlice.isHasNext())
+                .cursorId(cursorId)
+                .hasNext(hasNext)
                 .build();
     }
 

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -40,10 +40,11 @@ public class FollowFacade {
         return isAdd;
     }
 
-    public FollowSliceResponse<FollowingResponse> findFollowingList(Long memberId, Long cursorId) {
+    public FollowSliceResponse<FollowingResponse> findFollowingList(
+            Long memberId, Long requesterId, Long cursorId) {
         FollowSlice<Following> followingSlice =
                 followUseCase.getFollowingByMemberIdAndCursorId(memberId, cursorId);
-        Set<Long> blackMemberIds = blacklistQueryUseCase.getBlackMemberIds(memberId);
+        Set<Long> blackMemberIds = blacklistQueryUseCase.getBlackMemberIds(requesterId);
 
         List<Following> filteredFollowings =
                 followingSlice.getFollowContents().stream()
@@ -54,10 +55,11 @@ public class FollowFacade {
                 followingSlice, filteredFollowings, profileImageOrigin);
     }
 
-    public FollowSliceResponse<FollowerResponse> findFollowerList(Long memberId, Long cursorId) {
+    public FollowSliceResponse<FollowerResponse> findFollowerList(
+            Long memberId, Long requesterId, Long cursorId) {
         FollowSlice<Follower> followerSlice =
                 followUseCase.getFollowerByMemberIdAndCursorId(memberId, cursorId);
-        Set<Long> blackMemberIds = blacklistQueryUseCase.getBlackMemberIds(memberId);
+        Set<Long> blackMemberIds = blacklistQueryUseCase.getBlackMemberIds(requesterId);
         List<Follower> filteredFollowers =
                 followerSlice.getFollowContents().stream()
                         .filter(following -> !blackMemberIds.contains(following.getMemberId()))

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -63,8 +63,11 @@ public class FollowFacade {
                         .filter(following -> !blackMemberIds.contains(following.getMemberId()))
                         .toList();
 
+        Long newCursorId = followerSlice.getCursorId();
+        boolean hasNext = followerSlice.isHasNext();
+
         return FollowSliceResponse.toFollowerSliceResponses(
-                followerSlice, filteredFollowers, profileImageOrigin);
+                newCursorId, hasNext, filteredFollowers, profileImageOrigin);
     }
 
     public FollowingSummaryResponse findFollowingSummary(Long memberId) {

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberInfoResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberInfoResponse.java
@@ -14,8 +14,7 @@ public record MemberInfoResponse(
     @Builder
     public MemberInfoResponse {}
 
-    public static MemberInfoResponse toMemberInfoResponse(
-            MemberSearchInfo member, String profileImageOrigin) {
+    public static MemberInfoResponse of(MemberSearchInfo member, String profileImageOrigin) {
         return MemberInfoResponse.builder()
                 .memberId(member.getMemberId())
                 .nickname(member.getNickname())

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberInfoResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberInfoResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.member.dto.response;
 
+import com.depromeet.member.domain.vo.MemberSearchInfo;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -12,4 +13,14 @@ public record MemberInfoResponse(
         boolean hasFollowed) {
     @Builder
     public MemberInfoResponse {}
+
+    public static MemberInfoResponse toMemberInfoResponse(
+            MemberSearchInfo member, String profileImageOrigin) {
+        return MemberInfoResponse.builder()
+                .memberId(member.getMemberId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl(profileImageOrigin))
+                .introduction(member.getIntroduction())
+                .build();
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSearchResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSearchResponse.java
@@ -14,7 +14,7 @@ public record MemberSearchResponse(
     @Builder
     public MemberSearchResponse {}
 
-    public static MemberSearchResponse toMemberSearchResponse(
+    public static MemberSearchResponse of(
             Long cursorId,
             boolean hasNext,
             List<MemberSearchInfo> filteredMembers,
@@ -32,7 +32,7 @@ public record MemberSearchResponse(
     private static List<MemberInfoResponse> getMemberInfoResponses(
             List<MemberSearchInfo> filteredMembers, String profileImageOrigin) {
         return filteredMembers.stream()
-                .map(member -> MemberInfoResponse.toMemberInfoResponse(member, profileImageOrigin))
+                .map(member -> MemberInfoResponse.of(member, profileImageOrigin))
                 .toList();
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSearchResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/member/dto/response/MemberSearchResponse.java
@@ -1,6 +1,6 @@
 package com.depromeet.member.dto.response;
 
-import com.depromeet.member.domain.vo.MemberSearchPage;
+import com.depromeet.member.domain.vo.MemberSearchInfo;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import lombok.Builder;
@@ -15,30 +15,24 @@ public record MemberSearchResponse(
     public MemberSearchResponse {}
 
     public static MemberSearchResponse toMemberSearchResponse(
-            MemberSearchPage memberSearchPage, String profileImageDomain) {
+            Long cursorId,
+            boolean hasNext,
+            List<MemberSearchInfo> filteredMembers,
+            String profileImageDomain) {
         List<MemberInfoResponse> contents =
-                getMemberInfoResponses(memberSearchPage, profileImageDomain);
+                getMemberInfoResponses(filteredMembers, profileImageDomain);
         return MemberSearchResponse.builder()
                 .memberInfoResponses(contents)
-                .pageSize(memberSearchPage.getPageSize())
-                .cursorId(memberSearchPage.getCursorId())
-                .hasNext(memberSearchPage.isHasNext())
+                .pageSize(filteredMembers.size())
+                .cursorId(cursorId)
+                .hasNext(hasNext)
                 .build();
     }
 
     private static List<MemberInfoResponse> getMemberInfoResponses(
-            MemberSearchPage memberSearchPage, String profileImageOrigin) {
-        return memberSearchPage.getMembers().stream()
-                .map(
-                        member ->
-                                MemberInfoResponse.builder()
-                                        .memberId(member.getMemberId())
-                                        .nickname(member.getNickname())
-                                        .profileImageUrl(
-                                                member.getProfileImageUrl(profileImageOrigin))
-                                        .introduction(member.getIntroduction())
-                                        .hasFollowed(member.isHasFollowed())
-                                        .build())
+            List<MemberSearchInfo> filteredMembers, String profileImageOrigin) {
+        return filteredMembers.stream()
+                .map(member -> MemberInfoResponse.toMemberInfoResponse(member, profileImageOrigin))
                 .toList();
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -84,8 +84,7 @@ public class MemberFacade {
         Long newCursorId = memberSearchPage.getCursorId();
         boolean hasNext = memberSearchPage.isHasNext();
 
-        return MemberSearchResponse.toMemberSearchResponse(
-                newCursorId, hasNext, filteredMembers, profileImageOrigin);
+        return MemberSearchResponse.of(newCursorId, hasNext, filteredMembers, profileImageOrigin);
     }
 
     public MemberDetailResponse findDetailById(Long memberId) {

--- a/module-presentation/src/test/java/com/depromeet/friend/api/FollowControllerTest.java
+++ b/module-presentation/src/test/java/com/depromeet/friend/api/FollowControllerTest.java
@@ -90,7 +90,7 @@ public class FollowControllerTest extends ControllerTestConfig {
                         followingResponses, followingResponses.size(), null, false);
 
         // when
-        when(followFacade.findFollowingList(anyLong(), anyLong())).thenReturn(response);
+        when(followFacade.findFollowingList(anyLong(), anyLong(), anyLong())).thenReturn(response);
 
         // then
         mockMvc.perform(
@@ -121,7 +121,7 @@ public class FollowControllerTest extends ControllerTestConfig {
                 new FollowSliceResponse<>(followerResponses, followerResponses.size(), null, false);
 
         // when
-        when(followFacade.findFollowerList(anyLong(), anyLong())).thenReturn(response);
+        when(followFacade.findFollowerList(anyLong(), anyLong(), anyLong())).thenReturn(response);
 
         // then
         mockMvc.perform(


### PR DESCRIPTION
## 🌱 관련 이슈

- close #387 

## 📌 작업 내용 및 특이사항
- 유저를 검색할 때 차단한 사람/본인을 차단한 사람을 보이지 않게 하였습니다. 

## 📝 참고사항
- 차단 전 "김민" 으로 키워드 검색 시 결과
![유저 검색 김민석 차단 전](https://github.com/user-attachments/assets/493beda7-4796-4107-9086-33dddf3286fb)

- member_id 1번이 member_id 103(김민수) 차단, member_id 101(김민석)이 member_id 1 차단 후 "김민" 검색 결과
![유저 검색 김민석 차단 후](https://github.com/user-attachments/assets/d144961f-9ca0-4564-ac45-b6a7291fbcfc)

- "김민석" 검색 결과
![image](https://github.com/user-attachments/assets/455ad822-b97e-4a20-a8f7-7ff935459a81)

+) 다른 사람 팔로우/팔로잉 리스트 조회 시 본인이 차단/본인을 차단한 사람이 보이지 않게 수정하였습니다. 

100, 98, 97, 96, 95, 94, 92, 91 를 차단/차단당한 상태
![image](https://github.com/user-attachments/assets/7f011084-bfff-4083-95be-90e36ed58e4e)

![image](https://github.com/user-attachments/assets/8639e71d-6f38-4bf0-bf67-6ab7906d7c61)



