### PR TITLE
feat: 유저 차단 시 팔로워/팔로잉 리스트에서 삭제 및 차단한 유저/본인을 차단한 유저를 팔로우 할 때 예외 처리

### DIFF
--- a/module-domain/src/main/java/com/depromeet/friend/port/in/command/DeleteFollowCommand.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/in/command/DeleteFollowCommand.java
@@ -1,0 +1,3 @@
+package com.depromeet.friend.port.in.command;
+
+public record DeleteFollowCommand(Long requesterId, Long blackMemberId) {}

--- a/module-domain/src/main/java/com/depromeet/friend/port/in/usecase/FollowUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/in/usecase/FollowUseCase.java
@@ -1,6 +1,7 @@
-package com.depromeet.friend.port.in;
+package com.depromeet.friend.port.in.usecase;
 
 import com.depromeet.friend.domain.vo.*;
+import com.depromeet.friend.port.in.command.DeleteFollowCommand;
 import com.depromeet.member.domain.Member;
 import java.util.List;
 
@@ -22,4 +23,6 @@ public interface FollowUseCase {
     void deleteByMemberId(Long memberId);
 
     List<FollowCheck> checkFollowingState(Long memberId, List<Long> targetIds);
+
+    void deleteBlackMemberInFollowList(DeleteFollowCommand deleteFollowCommand);
 }

--- a/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/friend/port/out/persistence/FriendPersistencePort.java
@@ -14,6 +14,8 @@ public interface FriendPersistencePort {
 
     void deleteByMemberIdAndFollowingId(Long memberId, Long followingId);
 
+    void deleteFollowerFollowingByMemberIdAndFollowingId(Long memberId, Long followingId);
+
     List<Following> findFollowingsByMemberIdAndCursorId(Long memberId, Long cursorId);
 
     List<Follower> findFollowersByMemberIdAndCursorId(Long memberId, Long cursorId);

--- a/module-domain/src/test/java/com/depromeet/mock/friend/FakeFriendRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/friend/FakeFriendRepository.java
@@ -81,6 +81,9 @@ public class FakeFriendRepository implements FriendPersistencePort {
     }
 
     @Override
+    public void deleteFollowerFollowingByMemberIdAndFollowingId(Long memberId, Long followingId) {}
+
+    @Override
     public List<Following> findFollowingsByMemberIdAndCursorId(Long memberId, Long cursorId) {
         return friends.stream()
                 .filter(

--- a/module-independent/src/main/java/com/depromeet/type/friend/FollowErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/friend/FollowErrorType.java
@@ -5,7 +5,9 @@ import com.depromeet.type.ErrorType;
 public enum FollowErrorType implements ErrorType {
     NOT_FOUND("FOLLOW_1", "팔로잉 유저를 찾을 수 없습니다"),
     SELF_FOLLOWING_NOT_ALLOWED("FOLLOW_2", "자기 자신을 팔로잉 할 수 없습니다"),
-    INVALID_FOLLOW_TYPE("FOLLOW_3", "올바르지 않은 팔로우 타입입니다");
+    INVALID_FOLLOW_TYPE("FOLLOW_3", "올바르지 않은 팔로우 타입입니다"),
+    CANNOT_FOLLOW_BLACK("FOLLOW_4", "차단한 사람을 팔로우할 수 없습니다"),
+    CANNOT_FOLLOW_MEMBER_WHO_BLOCKED_YOU("FOLLOW_5", "본인을 차단한 사람을 팔로우할 수 없습니다");
 
     private final String code;
     private final String message;

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
@@ -70,6 +70,18 @@ public class FriendRepository implements FriendPersistencePort {
     }
 
     @Override
+    public void deleteFollowerFollowingByMemberIdAndFollowingId(Long memberId, Long followingId) {
+        queryFactory
+                .delete(friend)
+                .where(checkFollow(memberId, followingId).or(checkFollow(followingId, memberId)))
+                .execute();
+    }
+
+    private BooleanExpression checkFollow(Long memberId, Long followingId) {
+        return friend.member.id.eq(memberId).and(friend.following.id.eq(followingId));
+    }
+
+    @Override
     public List<Following> findFollowingsByMemberIdAndCursorId(Long memberId, Long cursorId) {
         return queryFactory
                 .select(

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -14,7 +14,7 @@ import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 import com.depromeet.dto.auth.AccountProfileResponse;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.followinglog.port.in.FollowingMemoryLogUseCase;
-import com.depromeet.friend.port.in.FollowUseCase;
+import com.depromeet.friend.port.in.usecase.FollowUseCase;
 import com.depromeet.image.port.in.ImageUpdateUseCase;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.mapper.MemberMapper;

--- a/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/facade/BlacklistFacade.java
@@ -6,9 +6,11 @@ import com.depromeet.blacklist.dto.response.BlackMemberResponse;
 import com.depromeet.blacklist.port.in.usecase.BlacklistCommandUseCase;
 import com.depromeet.blacklist.port.in.usecase.BlacklistQueryUseCase;
 import com.depromeet.exception.BadRequestException;
+import com.depromeet.friend.port.in.command.DeleteFollowCommand;
 import com.depromeet.type.blacklist.BlacklistErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class BlacklistFacade {
+    private final ApplicationEventPublisher eventPublisher;
     private final BlacklistQueryUseCase blacklistQueryUseCase;
     private final BlacklistCommandUseCase blacklistCommandUseCase;
 
@@ -34,6 +37,7 @@ public class BlacklistFacade {
         }
 
         blacklistCommandUseCase.blackMember(memberId, blackMemberId);
+        eventPublisher.publishEvent(new DeleteFollowCommand(memberId, blackMemberId));
     }
 
     public void unblackMember(Long memberId, Long blackMemberId) {

--- a/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/member/facade/MemberFacade.java
@@ -4,7 +4,7 @@ import static com.depromeet.member.service.MemberValidator.isMyProfile;
 
 import com.depromeet.blacklist.port.in.usecase.BlacklistQueryUseCase;
 import com.depromeet.friend.domain.vo.FriendCount;
-import com.depromeet.friend.port.in.FollowUseCase;
+import com.depromeet.friend.port.in.usecase.FollowUseCase;
 import com.depromeet.member.domain.Member;
 import com.depromeet.member.domain.MemberGender;
 import com.depromeet.member.domain.vo.MemberSearchInfo;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #393 

## 📌 작업 내용 및 특이사항
- 유저 차단 시 팔로워/팔로잉 리스트에서 삭제되는 기능을 추가했습니다. 
- 또한 이후 차단한 유저/차단당한 유저가 다시 팔로우 하는 것을 막기 위해 차단한 유저/본인을 차단한 유저가 팔로우를 하는 경우 예외 처리를 하였습니다.

## 📝 참고사항
- 차단 전 friend_entity db 상태
![차단 전 friend_entity db 상태](https://github.com/user-attachments/assets/ef41a9d3-ba8a-4404-be44-9dc841528709)
현재 1번과 2번이 맞팔, 1번이 3번을 팔로우, 3번이 2번을 팔로우 한 상태입니다. 

- 1번 유저가 2번을 차단
![2번 차단](https://github.com/user-attachments/assets/1c4b3e95-b443-4e8f-805c-c9fe92ea1811)

- 2번 차단 후 friend_entity db 상태
![image](https://github.com/user-attachments/assets/4d0c333f-e23a-4ff6-874a-e33c789efe63)

- 1번 유저가 3번 차단
![3번 차단](https://github.com/user-attachments/assets/0e2c8150-42e4-4b8d-a982-6a9bff5f5419)

- 3번 차단 후 friend_entity db 상태
![image](https://github.com/user-attachments/assets/1420a120-679f-4ec7-9cfe-79b770cdc374)

- 본인이 차단한 유저를 팔로우 시 에러 메시지
![차단한 사람 팔로우 시 에러](https://github.com/user-attachments/assets/9ace9a5b-c3f0-4180-a97a-78acfe6c443e)

- 차단 당한 사람이 팔로우 시 에러
![본인을 차단한 사람 팔로우 시 차단](https://github.com/user-attachments/assets/ee89c308-e917-474c-8f92-63dac70754d4)

