### PR TITLE
feat: 마이페이지 차단 구현

### DIFF
--- a/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistQueryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistQueryUseCase.java
@@ -9,4 +9,6 @@ public interface BlacklistQueryUseCase {
     BlacklistPage getBlackMembers(Long memberId, Long cursorId);
 
     Set<Long> getBlackMemberIds(Long memberId);
+
+    Boolean checkBlockOrBlocked(Long loginMemberId, Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
@@ -16,4 +16,6 @@ public interface BlacklistPersistencePort {
     List<Long> findBlackMemberIdsByMemberId(Long memberId);
 
     List<Long> findMemberIdsWhoBlockedMe(Long memberId);
+
+    Boolean isBlockOrBlocked(Long loginMemberId, Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
@@ -63,6 +63,11 @@ public class BlacklistService implements BlacklistQueryUseCase, BlacklistCommand
         return new HashSet<>(blackMemberIds);
     }
 
+    @Override
+    public Boolean checkBlockOrBlocked(Long loginMemberId, Long memberId) {
+        return blacklistPersistencePort.isBlockOrBlocked(loginMemberId, memberId);
+    }
+
     private List<Long> getBlackMemberIdsByMemberId(Long memberId) {
         return blacklistPersistencePort.findBlackMemberIdsByMemberId(memberId);
     }

--- a/module-domain/src/main/java/com/depromeet/report/domain/ReportReasonCode.java
+++ b/module-domain/src/main/java/com/depromeet/report/domain/ReportReasonCode.java
@@ -6,9 +6,9 @@ import com.depromeet.converter.CodedEnum;
 public enum ReportReasonCode implements CodedEnum<String> {
     REPORT_REASON_1("스팸, 광고"),
     REPORT_REASON_2("폭력적인 발언"),
-    REPORT_REASON_3("음란성, 선정 내용"),
+    REPORT_REASON_3("음란성, 선정성 내용"),
     REPORT_REASON_4("개인정보 노출"),
-    REPORT_REASON_5("주제와 무관");
+    REPORT_REASON_5("수영과 무관한 내용");
 
     private String value;
 

--- a/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/member/MemberErrorType.java
@@ -12,7 +12,8 @@ public enum MemberErrorType implements ErrorType {
     UPDATE_FAILED("MEMBER_7", "멤버의 정보 수정에 실패하였습니다"),
     UPDATE_PROFILE_IMAGE_FAILED("MEMBER_8", "멤버의 프로필 이미지 수정에 실패하였습니다"),
     UPDATE_LAST_VIEWED_FOLLOWING_LOG_AT("MEMBER_9", "멤버의 최근 팔로잉 소식 조회 시간 변경에 실패하였습니다"),
-    NOT_FOUND_FROM_ID_LIST("MEMBER_10", "요청된 멤버 ID 중 존재하지 않는 멤버가 있습니다");
+    NOT_FOUND_FROM_ID_LIST("MEMBER_10", "요청된 멤버 ID 중 존재하지 않는 멤버가 있습니다"),
+    MEMBER_BLOCK_OR_BLOCKED("MEMBER_11", "멤버를 차단했거나 멤버에게 차단 당했습니다");
 
     private final String code;
     private final String message;

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
@@ -25,7 +25,7 @@ public class MemberController implements MemberApi {
     public ApiResponse<MemberProfileResponse> getMember(
             @LoginMember Long memberId, @PathVariable("id") Long id) {
         return ApiResponse.success(
-                MemberSuccessType.GET_SUCCESS, memberFacade.findById(memberId, id));
+                MemberSuccessType.GET_SUCCESS, memberFacade.findByIdAndCheckBlack(memberId, id));
     }
 
     @PatchMapping

--- a/module-presentation/src/main/resources/application-prod.yml
+++ b/module-presentation/src/main/resources/application-prod.yml
@@ -5,7 +5,7 @@ spring:
     import: optional:application-secret.properties
   jpa:
     hibernate:
-      ddl-auto: update # 실제 서버에서 사용시 모든 데이터가 다 날아가므로 주의
+      ddl-auto: none # 실제 서버에서 사용시 모든 데이터가 다 날아가므로 주의
     defer-datasource-initialization: false
     properties:
       hibernate:


### PR DESCRIPTION
## 🌱 관련 이슈

- close #389

## 📌 작업 내용 및 특이사항
- 마이페이지 차단을 구현하였습니다.
- 차단한/차단 당한 회원의 마이페이지에 접근하면 403 에러가 발생합니다.
- 쿼리는 다음과 같습니다.

<details>
<summary>펼치기</summary>

```
Hibernate: 
    select
        be1_0.blacklist_id 
    from
        blacklist_entity be1_0 
    join
        member_entity m1_0 
            on m1_0.member_id=be1_0.member_id 
    join
        member_entity bm1_0 
            on bm1_0.member_id=be1_0.black_target_id 
    where
        be1_0.member_id=? 
        and be1_0.black_target_id=? 
        or be1_0.member_id=? 
        and be1_0.black_target_id=?
```
</details>

## 📝 참고사항
- 차단했거나/차단 당했다면 오류
<img width="833" alt="Screenshot 2024-09-07 at 15 20 39" src="https://github.com/user-attachments/assets/c0c6421a-7575-4209-884e-aa4c109f2142">

- 기존 회원 정보 조회는 잘 됨
<img width="842" alt="Screenshot 2024-09-07 at 15 20 32" src="https://github.com/user-attachments/assets/544b1772-7271-49b7-aac1-d0f177e04d7e">