### PR TITLE
fix: 회원 탈퇴 시 차단 데이터 삭제

### DIFF
--- a/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistQueryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/in/usecase/BlacklistQueryUseCase.java
@@ -11,4 +11,6 @@ public interface BlacklistQueryUseCase {
     Set<Long> getBlackMemberIds(Long memberId);
 
     Boolean checkBlockOrBlocked(Long loginMemberId, Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/port/out/persistence/BlacklistPersistencePort.java
@@ -18,4 +18,6 @@ public interface BlacklistPersistencePort {
     List<Long> findMemberIdsWhoBlockedMe(Long memberId);
 
     Boolean isBlockOrBlocked(Long loginMemberId, Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
+++ b/module-domain/src/main/java/com/depromeet/blacklist/service/BlacklistService.java
@@ -68,6 +68,11 @@ public class BlacklistService implements BlacklistQueryUseCase, BlacklistCommand
         return blacklistPersistencePort.isBlockOrBlocked(loginMemberId, memberId);
     }
 
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        blacklistPersistencePort.deleteAllByMemberId(memberId);
+    }
+
     private List<Long> getBlackMemberIdsByMemberId(Long memberId) {
         return blacklistPersistencePort.findBlackMemberIdsByMemberId(memberId);
     }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/blacklist/repository/BlacklistRepository.java
@@ -90,6 +90,14 @@ public class BlacklistRepository implements BlacklistPersistencePort {
                 .isEmpty();
     }
 
+    @Override
+    public void deleteAllByMemberId(Long memberId) {
+        queryFactory
+                .delete(blacklistEntity)
+                .where(memberEq(memberId).or(blackMemberEq(memberId)))
+                .execute();
+    }
+
     private static BooleanExpression memberEq(Long memberId) {
         if (memberId == null) {
             return null;

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -11,6 +11,7 @@ import com.depromeet.auth.port.in.usecase.SocialUseCase;
 import com.depromeet.auth.vo.AccessTokenInfo;
 import com.depromeet.auth.vo.JwtToken;
 import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
+import com.depromeet.blacklist.port.in.usecase.BlacklistQueryUseCase;
 import com.depromeet.dto.auth.AccountProfileResponse;
 import com.depromeet.exception.NotFoundException;
 import com.depromeet.followinglog.port.in.FollowingMemoryLogUseCase;
@@ -51,6 +52,7 @@ public class AuthFacade {
     private final ImageUpdateUseCase imageUpdateUseCase;
     private final DeleteMemoryUseCase deleteMemoryUseCase;
     private final FavoritePoolUseCase favoritePoolUseCase;
+    private final BlacklistQueryUseCase blacklistQueryUseCase;
     private final DeleteReactionUseCase deleteReactionUseCase;
     private final DeleteFollowLogUseCase deleteFollowLogUseCase;
     private final DeleteReactionLogUseCase deleteReactionLogUseCase;
@@ -148,6 +150,8 @@ public class AuthFacade {
         followUseCase.deleteByMemberId(memberId);
         // Follow log 삭제
         deleteFollowLogUseCase.deleteAllByMemberId(memberId);
+        // Blacklist 삭제
+        blacklistQueryUseCase.deleteAllByMemberId(memberId);
         // Member 삭제
         memberUseCase.deleteById(memberId);
         socialUseCase.revokeAccount(accountType);


### PR DESCRIPTION
## 🌱 관련 이슈

- close #400

## 📌 작업 내용 및 특이사항
- 회원 탈퇴 시 차단 데이터도 삭제하는 메서드를 추가하였습니다.

## 📝 참고사항
- id 10번 회원 탈퇴 성공
<img width="374" alt="Screenshot 2024-09-08 at 23 16 47" src="https://github.com/user-attachments/assets/83a8da1a-6027-402d-9a97-91241b102832">
<img width="845" alt="Screenshot 2024-09-08 at 23 17 02" src="https://github.com/user-attachments/assets/ad9a15ca-1614-44da-bf4a-d12314facf5e">