### PR TITLE
refactor: 팔로워/팔로우 리스트 리팩토링 및 타임라인 리팩토링

### DIFF
--- a/module-domain/src/main/java/com/depromeet/friend/domain/vo/Follower.java
+++ b/module-domain/src/main/java/com/depromeet/friend/domain/vo/Follower.java
@@ -15,7 +15,6 @@ public class Follower {
     private String name;
     private String profileImageUrl;
     private String introduction;
-    private boolean hasFollowedBack;
 
     @Builder
     public Follower(
@@ -23,14 +22,12 @@ public class Follower {
             Long memberId,
             String name,
             String profileImageUrl,
-            String introduction,
-            boolean hasFollowedBack) {
+            String introduction) {
         this.friendId = friendId;
         this.memberId = memberId;
         this.name = name;
         this.profileImageUrl = profileImageUrl;
         this.introduction = introduction;
-        this.hasFollowedBack = hasFollowedBack;
     }
 
     public String getProfileImageUrl(String profileImageOrigin) {

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/friend/repository/FriendRepository.java
@@ -1,7 +1,6 @@
 package com.depromeet.friend.repository;
 
 import static com.depromeet.friend.entity.QFriendEntity.friendEntity;
-import static com.querydsl.jpa.JPAExpressions.select;
 
 import com.depromeet.friend.domain.Friend;
 import com.depromeet.friend.domain.vo.*;
@@ -10,10 +9,8 @@ import com.depromeet.friend.entity.QFriendEntity;
 import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
 import com.depromeet.member.entity.QMemberEntity;
 import com.querydsl.core.Tuple;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -101,7 +98,6 @@ public class FriendRepository implements FriendPersistencePort {
 
     @Override
     public List<Follower> findFollowersByMemberIdAndCursorId(Long memberId, Long cursorId) {
-        QFriendEntity subFriend = new QFriendEntity("sub");
         return queryFactory
                 .select(
                         Projections.constructor(
@@ -110,15 +106,7 @@ public class FriendRepository implements FriendPersistencePort {
                                 friend.member.id.as("memberId"),
                                 friend.member.nickname.as("name"),
                                 friend.member.profileImageUrl.as("profileImageUrl"),
-                                friend.member.introduction.as("introduction"),
-                                ExpressionUtils.as(
-                                        select(Expressions.constant(true))
-                                                .from(subFriend)
-                                                .where(
-                                                        friend.member.id.eq(subFriend.following.id),
-                                                        friend.following.id.eq(
-                                                                subFriend.member.id)),
-                                        "hasFollowedBack")))
+                                friend.member.introduction.as("introduction")))
                 .from(friend)
                 .where(friend.following.id.eq(memberId), ltCursorId(cursorId))
                 .limit(11)

--- a/module-infrastructure/persistence-database/src/test/java/com/depromeet/friend/repository/FriendRepositoryTest.java
+++ b/module-infrastructure/persistence-database/src/test/java/com/depromeet/friend/repository/FriendRepositoryTest.java
@@ -149,8 +149,6 @@ public class FriendRepositoryTest {
                                                 .friendId(friend.getId())
                                                 .memberId(friend.getMember().getId())
                                                 .name(friend.getMember().getNickname())
-                                                .hasFollowedBack(
-                                                        friend.getMember().getId() % 2 == 0)
                                                 .build())
                         .toList();
         List<String> expectedFollowerNames =

--- a/module-infrastructure/persistence-redis/src/main/java/com/depromeet/redis/config/RedisCacheConfig.java
+++ b/module-infrastructure/persistence-redis/src/main/java/com/depromeet/redis/config/RedisCacheConfig.java
@@ -1,0 +1,34 @@
+package com.depromeet.redis.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration =
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()))
+                        .entryTtl(Duration.ofHours(3L));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(
+                        redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
@@ -97,7 +97,7 @@ public record FollowingLogMemoryResponse(
     @Builder
     public FollowingLogMemoryResponse {}
 
-    public static FollowingLogMemoryResponse toFollowingLogMemoryResponse(
+    public static FollowingLogMemoryResponse of(
             FollowingMemoryLog followingMemoryLog,
             LocalDateTime lastViewedFollowingLogAt,
             String profileImageOrigin) {

--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogMemoryResponse.java
@@ -133,9 +133,7 @@ public record FollowingLogMemoryResponse(
 
     private static List<StrokeResponse> strokeToDto(List<Stroke> strokes, Short lane) {
         if (strokes == null || strokes.isEmpty()) return new ArrayList<>();
-        return strokes.stream()
-                .map(stroke -> StrokeResponse.toStrokeResponse(stroke, lane))
-                .toList();
+        return strokes.stream().map(stroke -> StrokeResponse.of(stroke, lane)).toList();
     }
 
     private static boolean checkIsRecentLog(

--- a/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/dto/response/FollowingLogSliceResponse.java
@@ -43,7 +43,7 @@ public class FollowingLogSliceResponse {
         this.hasNext = hasNext;
     }
 
-    public static FollowingLogSliceResponse toFollowingLogSliceResponse(
+    public static FollowingLogSliceResponse of(
             FollowingLogSlice followingLogSlice,
             LocalDateTime lastViewedFollowingLogAt,
             String profileImageOrigin) {
@@ -51,7 +51,7 @@ public class FollowingLogSliceResponse {
                 followingLogSlice.getContents().stream()
                         .map(
                                 followingMemoryLog ->
-                                        FollowingLogMemoryResponse.toFollowingLogMemoryResponse(
+                                        FollowingLogMemoryResponse.of(
                                                 followingMemoryLog,
                                                 lastViewedFollowingLogAt,
                                                 profileImageOrigin))

--- a/module-presentation/src/main/java/com/depromeet/followinglog/facade/FollowingLogFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/facade/FollowingLogFacade.java
@@ -27,7 +27,7 @@ public class FollowingLogFacade {
                 followingMemoryLogUseCase.findLogsByMemberIdAndCursorId(memberId, cursorId);
         Member member = memberUseCase.findById(memberId);
         FollowingLogSliceResponse followingLogSliceResponse =
-                FollowingLogSliceResponse.toFollowingLogSliceResponse(
+                FollowingLogSliceResponse.of(
                         followingLogSlice,
                         member.getLastViewedFollowingLogAt(),
                         profileImageOrigin);

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
@@ -1,6 +1,5 @@
 package com.depromeet.friend.dto.response;
 
-import com.depromeet.friend.domain.vo.FollowSlice;
 import com.depromeet.friend.domain.vo.Follower;
 import com.depromeet.friend.domain.vo.Following;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -27,8 +26,9 @@ public record FollowSliceResponse<T>(
     @Builder
     public FollowSliceResponse {}
 
-    public static FollowSliceResponse<FollowingResponse> toFollowingSliceResponse(
-            FollowSlice<Following> followingSlice,
+    public static FollowSliceResponse<FollowingResponse> followingOf(
+            Long cursorId,
+            boolean hasNext,
             List<Following> filteredFollowings,
             String profileImageDomain) {
         List<FollowingResponse> followingResponses =
@@ -36,12 +36,12 @@ public record FollowSliceResponse<T>(
         return FollowSliceResponse.<FollowingResponse>builder()
                 .contents(followingResponses)
                 .pageSize(followingResponses.size())
-                .cursorId(followingSlice.getCursorId())
-                .hasNext(followingSlice.isHasNext())
+                .cursorId(cursorId)
+                .hasNext(hasNext)
                 .build();
     }
 
-    public static FollowSliceResponse<FollowerResponse> toFollowerSliceResponses(
+    public static FollowSliceResponse<FollowerResponse> followerOf(
             Long cursorId,
             boolean hasNext,
             List<Follower> filteredFollowers,
@@ -82,7 +82,6 @@ public record FollowSliceResponse<T>(
                                         .profileImageUrl(
                                                 follower.getProfileImageUrl(profileImageOrigin))
                                         .introduction(follower.getIntroduction())
-                                        .hasFollowedBack(follower.isHasFollowedBack())
                                         .build())
                 .toList();
     }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowSliceResponse.java
@@ -59,30 +59,14 @@ public record FollowSliceResponse<T>(
     private static List<FollowingResponse> getFollowingResponses(
             List<Following> followings, String profileImageOrigin) {
         return followings.stream()
-                .map(
-                        following ->
-                                FollowingResponse.builder()
-                                        .memberId(following.getMemberId())
-                                        .nickname(following.getName())
-                                        .profileImageUrl(
-                                                following.getProfileImageUrl(profileImageOrigin))
-                                        .introduction(following.getIntroduction())
-                                        .build())
+                .map(following -> FollowingResponse.of(following, profileImageOrigin))
                 .toList();
     }
 
     private static List<FollowerResponse> getFollowerResponses(
             List<Follower> followers, String profileImageOrigin) {
         return followers.stream()
-                .map(
-                        follower ->
-                                FollowerResponse.builder()
-                                        .memberId(follower.getMemberId())
-                                        .nickname(follower.getName())
-                                        .profileImageUrl(
-                                                follower.getProfileImageUrl(profileImageOrigin))
-                                        .introduction(follower.getIntroduction())
-                                        .build())
+                .map(follower -> FollowerResponse.of(follower, profileImageOrigin))
                 .toList();
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowerResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowerResponse.java
@@ -1,5 +1,6 @@
 package com.depromeet.friend.dto.response;
 
+import com.depromeet.friend.domain.vo.Follower;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -25,12 +26,16 @@ public record FollowerResponse(
                         description = "팔로잉 member PK",
                         example = "안녕하세요. 홍길동입니다",
                         requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-                String introduction,
-        @Schema(
-                        description = "맞팔 유무",
-                        example = "false",
-                        requiredMode = Schema.RequiredMode.REQUIRED)
-                boolean hasFollowedBack) {
+                String introduction) {
     @Builder
     public FollowerResponse {}
+
+    public static FollowerResponse of(Follower follower, String profileImageOrigin) {
+        return FollowerResponse.builder()
+                .memberId(follower.getMemberId())
+                .nickname(follower.getName())
+                .profileImageUrl(follower.getProfileImageUrl(profileImageOrigin))
+                .introduction(follower.getIntroduction())
+                .build();
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingResponse.java
@@ -30,8 +30,7 @@ public record FollowingResponse(
     @Builder
     public FollowingResponse {}
 
-    public static FollowingResponse toFollowingResponse(
-            Following following, String profileImageOrigin) {
+    public static FollowingResponse of(Following following, String profileImageOrigin) {
         return FollowingResponse.builder()
                 .memberId(following.getMemberId())
                 .nickname(following.getName())

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingStateResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingStateResponse.java
@@ -13,7 +13,7 @@ public record FollowingStateResponse(
                         example = "[true, false, true]",
                         requiredMode = Schema.RequiredMode.REQUIRED)
                 List<FollowCheckResponse> followingList) {
-    public static FollowingStateResponse toIsFollowingResponse(List<FollowCheck> followCheckVos) {
+    public static FollowingStateResponse from(List<FollowCheck> followCheckVos) {
         return new FollowingStateResponse(
                 followCheckVos.stream().map(FollowCheckResponse::of).toList());
     }

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingSummaryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingSummaryResponse.java
@@ -15,7 +15,7 @@ public record FollowingSummaryResponse(
     @Builder
     public FollowingSummaryResponse {}
 
-    public static FollowingSummaryResponse toFollowingSummaryResponse(
+    public static FollowingSummaryResponse of(
             int followingCount, List<Following> followings, String profileImageOrigin) {
         List<FollowingResponse> followingResponses =
                 followings.stream()

--- a/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingSummaryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/dto/response/FollowingSummaryResponse.java
@@ -19,10 +19,7 @@ public record FollowingSummaryResponse(
             int followingCount, List<Following> followings, String profileImageOrigin) {
         List<FollowingResponse> followingResponses =
                 followings.stream()
-                        .map(
-                                following ->
-                                        FollowingResponse.toFollowingResponse(
-                                                following, profileImageOrigin))
+                        .map(following -> FollowingResponse.of(following, profileImageOrigin))
                         .toList();
 
         return FollowingSummaryResponse.builder()

--- a/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/facade/FollowFacade.java
@@ -61,8 +61,11 @@ public class FollowFacade {
                         .filter(following -> !blackMemberIds.contains(following.getMemberId()))
                         .toList();
 
-        return FollowSliceResponse.toFollowingSliceResponse(
-                followingSlice, filteredFollowings, profileImageOrigin);
+        Long newCursorId = followingSlice.getCursorId();
+        boolean hasNext = followingSlice.isHasNext();
+
+        return FollowSliceResponse.followingOf(
+                newCursorId, hasNext, filteredFollowings, profileImageOrigin);
     }
 
     public FollowSliceResponse<FollowerResponse> findFollowerList(
@@ -78,7 +81,7 @@ public class FollowFacade {
         Long newCursorId = followerSlice.getCursorId();
         boolean hasNext = followerSlice.isHasNext();
 
-        return FollowSliceResponse.toFollowerSliceResponses(
+        return FollowSliceResponse.followerOf(
                 newCursorId, hasNext, filteredFollowers, profileImageOrigin);
     }
 
@@ -86,13 +89,12 @@ public class FollowFacade {
         int followingCount = followUseCase.countFollowingByMemberId(memberId);
         List<Following> followings = followUseCase.getFollowingByMemberIdLimitThree(memberId);
 
-        return FollowingSummaryResponse.toFollowingSummaryResponse(
-                followingCount, followings, profileImageOrigin);
+        return FollowingSummaryResponse.of(followingCount, followings, profileImageOrigin);
     }
 
     @Transactional(readOnly = true)
     public FollowingStateResponse checkFollowingState(Long memberId, List<Long> targetIds) {
         List<FollowCheck> followCheckVos = followUseCase.checkFollowingState(memberId, targetIds);
-        return FollowingStateResponse.toIsFollowingResponse(followCheckVos);
+        return FollowingStateResponse.from(followCheckVos);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/StrokeResponse.java
@@ -14,7 +14,7 @@ public record StrokeResponse(
     @Builder
     public StrokeResponse {}
 
-    public static StrokeResponse toStrokeResponse(Stroke stroke, Short lane) {
+    public static StrokeResponse of(Stroke stroke, Short lane) {
         return StrokeResponse.builder()
                 .strokeId(stroke.getId())
                 .name(stroke.getName())

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineResponse.java
@@ -76,7 +76,7 @@ public record TimelineResponse(
     @Builder
     public TimelineResponse {}
 
-    public static TimelineResponse mapToTimelineResponseDto(
+    public static TimelineResponse of(
             Memory memory,
             List<ReactionCount> reactionCounts,
             Map<Long, MemoryImageUrlVo> memoryImageUrls,
@@ -121,9 +121,7 @@ public record TimelineResponse(
 
     private static List<StrokeResponse> strokeToDto(List<Stroke> strokes, Short lane) {
         if (strokes == null || strokes.isEmpty()) return new ArrayList<>();
-        return strokes.stream()
-                .map(stroke -> StrokeResponse.toStrokeResponse(stroke, lane))
-                .toList();
+        return strokes.stream().map(stroke -> StrokeResponse.of(stroke, lane)).toList();
     }
 
     private static Integer getKcalFromMemoryDetail(Memory memory) {

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
@@ -4,11 +4,13 @@ import com.depromeet.image.domain.vo.MemoryImageUrlVo;
 import com.depromeet.member.domain.Member;
 import com.depromeet.memory.domain.vo.TimelineSlice;
 import com.depromeet.reaction.domain.vo.ReactionCount;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record TimelineSliceResponse(
         @Schema(description = "타임라인 리스트", requiredMode = Schema.RequiredMode.REQUIRED)
                 List<TimelineResponse> content,

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/TimelineSliceResponse.java
@@ -1,7 +1,12 @@
 package com.depromeet.memory.dto.response;
 
+import com.depromeet.image.domain.vo.MemoryImageUrlVo;
+import com.depromeet.member.domain.Member;
+import com.depromeet.memory.domain.vo.TimelineSlice;
+import com.depromeet.reaction.domain.vo.ReactionCount;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 
 public record TimelineSliceResponse(
@@ -26,4 +31,35 @@ public record TimelineSliceResponse(
                 boolean hasNext) {
     @Builder
     public TimelineSliceResponse {}
+
+    public static TimelineSliceResponse of(
+            Member member,
+            TimelineSlice timelineSlice,
+            List<ReactionCount> reactionCounts,
+            Map<Long, MemoryImageUrlVo> memoryImageUrls,
+            String imageOrigin) {
+        List<TimelineResponse> result =
+                timelineSlice.getTimelineContents().stream()
+                        .map(
+                                memory ->
+                                        TimelineResponse.of(
+                                                memory,
+                                                reactionCounts,
+                                                memoryImageUrls,
+                                                imageOrigin))
+                        .toList();
+        return TimelineSliceResponse.builder()
+                .content(result)
+                .goal(member.getGoal())
+                .pageSize(timelineSlice.getPageSize())
+                .cursorRecordAt(getCursorRecordAtResponse(timelineSlice))
+                .hasNext(timelineSlice.isHasNext())
+                .build();
+    }
+
+    private static String getCursorRecordAtResponse(TimelineSlice timelineSlice) {
+        return timelineSlice.getCursorRecordAt() != null
+                ? timelineSlice.getCursorRecordAt().toString()
+                : null;
+    }
 }

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -125,7 +125,7 @@ public class MemoryFacade {
         List<ReactionCount> reactionCounts =
                 getReactionUseCase.getDetailReactionsCountByMemoryIds(memoryIds);
 
-        return MemoryMapper.toSliceResponse(
+        return TimelineSliceResponse.of(
                 member, timelineSlice, reactionCounts, memoryImageUrls, imageOrigin);
     }
 

--- a/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/mapper/MemoryMapper.java
@@ -1,22 +1,14 @@
 package com.depromeet.memory.mapper;
 
-import com.depromeet.image.domain.vo.MemoryImageUrlVo;
-import com.depromeet.member.domain.Member;
-import com.depromeet.memory.domain.vo.TimelineSlice;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;
 import com.depromeet.memory.dto.request.MemoryUpdateRequest;
 import com.depromeet.memory.dto.request.StrokeCreateRequest;
 import com.depromeet.memory.dto.request.StrokeUpdateRequest;
-import com.depromeet.memory.dto.response.TimelineResponse;
-import com.depromeet.memory.dto.response.TimelineSliceResponse;
 import com.depromeet.memory.port.in.command.CreateMemoryCommand;
 import com.depromeet.memory.port.in.command.CreateStrokeCommand;
 import com.depromeet.memory.port.in.command.UpdateMemoryCommand;
 import com.depromeet.memory.port.in.command.UpdateStrokeCommand;
-import com.depromeet.reaction.domain.vo.ReactionCount;
 import java.time.LocalTime;
-import java.util.List;
-import java.util.Map;
 
 public class MemoryMapper {
     public static CreateStrokeCommand toCommand(StrokeCreateRequest request) {
@@ -80,36 +72,5 @@ public class MemoryMapper {
             return LocalTime.of(0, min, sec);
         }
         return null;
-    }
-
-    public static TimelineSliceResponse toSliceResponse(
-            Member member,
-            TimelineSlice timelineSlice,
-            List<ReactionCount> reactionCounts,
-            Map<Long, MemoryImageUrlVo> memoryImageUrls,
-            String imageOrigin) {
-        List<TimelineResponse> result =
-                timelineSlice.getTimelineContents().stream()
-                        .map(
-                                memory ->
-                                        TimelineResponse.mapToTimelineResponseDto(
-                                                memory,
-                                                reactionCounts,
-                                                memoryImageUrls,
-                                                imageOrigin))
-                        .toList();
-        return TimelineSliceResponse.builder()
-                .content(result)
-                .goal(member.getGoal())
-                .pageSize(timelineSlice.getPageSize())
-                .cursorRecordAt(getCursorRecordAtResponse(timelineSlice))
-                .hasNext(timelineSlice.isHasNext())
-                .build();
-    }
-
-    private static String getCursorRecordAtResponse(TimelineSlice timelineSlice) {
-        return timelineSlice.getCursorRecordAt() != null
-                ? timelineSlice.getCursorRecordAt().toString()
-                : null;
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #358 

## 📌 작업 내용 및 특이사항
- 팔로우/팔로잉 리스트에서 불필요한 필드 및 로직을 제거하였습니다.
- 팔로우/팔로잉 실행계획 분석 결과 Backward index 가 나타나는 것을 확인하고 인덱스를 적용하였으나 k6 성능 테스트 결과 유의미한 차이를 보이지 않아 적용하지 않았습니다.
![image](https://github.com/user-attachments/assets/ec6cfb6d-f379-4f88-8a62-25d7ff51988c)

1번의 유저가 팔로잉 유저 50 명을 가지고 있는 상태에서 테스트 진행
- following index 적용 전 
![20240909 following 10 1 100 no index](https://github.com/user-attachments/assets/41b9f904-5835-491b-8f2a-336965f323fb)

- following index 적용 후
![20240909 following 10 1 100 index](https://github.com/user-attachments/assets/f5aa4e0a-5d80-4aaa-99eb-c5ff02661cd8)

- redisCache를 적용하기 위해 RedisCacheConfig를 추가하였으나 이 또한 큰 차이가 없어서 Config만 추가하였습니다. cache 같은 경우는 타임라인이나 캘린더 조회시 사용하면 도움이 될 것 같습니다. 
![image](https://github.com/user-attachments/assets/96536c98-2ecf-4f48-aacd-7f2ec70d4ece)

## 📝 참고사항
- 추가적으로 of 팩토리 메서드 컨벤션이 적용되지 않는 메서드 대상으로 of 컨벤션을 적용하였습니다. 

- 리팩토링 후 테스트 결과 팔로우/팔로잉 리스트 및 타임라인 조회 API 정상 작동 하는 것을 확인했습니다

  - 팔로잉 리스트 조회 결과
![image](https://github.com/user-attachments/assets/5cfc7848-451c-472f-a962-6b1561fabdad)

  - 팔로워 리스트 조회 결과
![image](https://github.com/user-attachments/assets/b93a1a94-4910-45e4-a6e9-8df4ad2a4d19)

  - 타임라인 조회 결과
![image](https://github.com/user-attachments/assets/91df838f-bceb-4341-b28a-23b573183ab2)
