### PR TITLE
fix: 회원 탈퇴 시 MemoryDetailId NPE 수정 및 애플 로그인 오류 코드 반환

### DIFF
--- a/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
+++ b/module-independent/src/main/java/com/depromeet/type/auth/AuthErrorType.java
@@ -25,7 +25,8 @@ public enum AuthErrorType implements ErrorType {
     GENERATE_APPLE_PUBLIC_KEY_FAILED("AUTH_21", "APPLE 공개키 생성에 실패하였습니다"),
     CANNOT_FIND_MATCH_JWK("AUTH_22", "일치하는 APPLE JWK 를 찾을 수 없습니다"),
     JWT_PARSE_FAILED("AUTH_23", "JWT PARSING 에 실패하였습니다"),
-    REVOKE_APPLE_ACCOUNT_FAILED("AUTH_24", "APPLE 계정 연결 끊기에 실패하였습니다");
+    REVOKE_APPLE_ACCOUNT_FAILED("AUTH_24", "APPLE 계정 연결 끊기에 실패하였습니다"),
+    CANNOT_GET_USER_DETAIL("AUTH_25", "인증 서버로부터 계정의 이메일, 이름 정보를 받아오는 데 실패하였습니다");
 
     private final String code;
     private final String message;

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -14,6 +14,7 @@ import com.depromeet.auth.vo.kakao.KakaoAccountProfile;
 import com.depromeet.blacklist.port.in.usecase.BlacklistQueryUseCase;
 import com.depromeet.dto.auth.AccountProfileResponse;
 import com.depromeet.exception.NotFoundException;
+import com.depromeet.exception.UnauthorizedException;
 import com.depromeet.followinglog.port.in.FollowingMemoryLogUseCase;
 import com.depromeet.friend.port.in.usecase.FollowUseCase;
 import com.depromeet.image.port.in.ImageUpdateUseCase;
@@ -31,6 +32,8 @@ import com.depromeet.pool.port.in.usecase.SearchLogUseCase;
 import com.depromeet.reaction.port.in.usecase.DeleteReactionUseCase;
 import com.depromeet.reaction.port.in.usecase.GetReactionUseCase;
 import com.depromeet.type.auth.AuthErrorType;
+
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
@@ -96,6 +99,8 @@ public class AuthFacade {
         String providerId = provider + " " + profile.id();
         Member member = memberUseCase.findByProviderId(providerId);
         if (member == null) {
+            // Email, Username 정보를 받아오지 못했으면 에러
+            checkRequiredFields(profile);
             isSignUpComplete = false;
             ThreadLocalRandom rand = ThreadLocalRandom.current();
             String defaultProfile = String.valueOf(rand.nextInt(4) + 1);
@@ -107,6 +112,12 @@ public class AuthFacade {
 
         return JwtTokenResponse.of(
                 token, member.getNickname(), member.getProfileImageUrl(), isSignUpComplete);
+    }
+
+    private static void checkRequiredFields(AccountProfileResponse profile) {
+        if (profile.name() == null || profile.email() == null) {
+            throw new UnauthorizedException(AuthErrorType.CANNOT_GET_USER_DETAIL);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -125,6 +136,7 @@ public class AuthFacade {
                 getMemoryUseCase.findMemoryAndDetailIdsByMemberId(memberId);
         List<Long> memoryIds = memoryAndDetailId.memoryIds();
         List<Long> memoryDetailIds = memoryAndDetailId.memoryDetailIds();
+        memoryDetailIds.removeAll(Collections.singletonList(null));
         // Following memory log 삭제
         followingMemoryLogUseCase.deleteAllByMemoryIds(memoryIds);
         // Reaction 조회
@@ -141,9 +153,7 @@ public class AuthFacade {
         // Memory 삭제
         deleteMemoryUseCase.deleteAllMemoryByMemberId(memberId);
         // MemoryDetail 삭제
-        if (memoryDetailIds != null && !memoryDetailIds.isEmpty()) {
-            deleteMemoryUseCase.deleteAllMemoryDetailById(memoryDetailIds);
-        }
+        deleteMemoryUseCase.deleteAllMemoryDetailById(memoryDetailIds);
         // Favorite pool 삭제
         favoritePoolUseCase.deleteAllFavoritePoolByMemberId(memberId);
         // Pool search 삭제

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -99,7 +99,7 @@ public class AuthFacade {
         Member member = memberUseCase.findByProviderId(providerId);
         if (member == null) {
             // Email, Username 정보를 받아오지 못했으면 에러
-            checkRequiredFields(profile);
+            checkRequiredFields(profile, provider);
             isSignUpComplete = false;
             ThreadLocalRandom rand = ThreadLocalRandom.current();
             String defaultProfile = String.valueOf(rand.nextInt(4) + 1);
@@ -113,8 +113,9 @@ public class AuthFacade {
                 token, member.getNickname(), member.getProfileImageUrl(), isSignUpComplete);
     }
 
-    private static void checkRequiredFields(AccountProfileResponse profile) {
+    private void checkRequiredFields(AccountProfileResponse profile, String provider) {
         if (profile.name() == null || profile.email() == null) {
+            socialUseCase.revokeAccount(provider);
             throw new UnauthorizedException(AuthErrorType.CANNOT_GET_USER_DETAIL);
         }
     }

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -32,7 +32,6 @@ import com.depromeet.pool.port.in.usecase.SearchLogUseCase;
 import com.depromeet.reaction.port.in.usecase.DeleteReactionUseCase;
 import com.depromeet.reaction.port.in.usecase.GetReactionUseCase;
 import com.depromeet.type.auth.AuthErrorType;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #406

## 📌 작업 내용 및 특이사항
- 회원 탈퇴 시 MemoryDetailId NPE를 다시 수정하였습니다.
- 소셜로그인 실패 시 연결 끊기를 진행하고, 오류 코드를 반환할 수 있도록 변경하였습니다.
- 해당 문제점들을 배포 서버 환경에서 확인할 수 있어 급하게 배포 먼저 진행하는 점 양해 부탁드립니다.