### PR TITLE
fix: 애플로그인 인증서버로부터 계정 정보를 받지 못할 때 에러 핸들링

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -85,7 +85,7 @@ public class AuthFacade {
     public JwtTokenResponse loginByApple(AppleLoginRequest request) {
         final AccountProfileResponse profile =
                 socialUseCase.getAppleAccountToken(
-                        AppleMapper.toCommand(request), "https://swimie.life");
+                        AppleMapper.toCommand(request), "https://patient-ocelot-accurate.ngrok-free.app");
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }
@@ -98,7 +98,7 @@ public class AuthFacade {
         Member member = memberUseCase.findByProviderId(providerId);
         if (member == null) {
             // Email, Username 정보를 받아오지 못했으면 에러
-            checkRequiredFields(profile, provider);
+            checkRequiredFields(profile, providerId);
             isSignUpComplete = false;
             ThreadLocalRandom rand = ThreadLocalRandom.current();
             String defaultProfile = String.valueOf(rand.nextInt(4) + 1);
@@ -112,9 +112,9 @@ public class AuthFacade {
                 token, member.getNickname(), member.getProfileImageUrl(), isSignUpComplete);
     }
 
-    private void checkRequiredFields(AccountProfileResponse profile, String provider) {
+    private void checkRequiredFields(AccountProfileResponse profile, String providerId) {
         if (profile.name() == null || profile.email() == null) {
-            socialUseCase.revokeAccount(provider);
+            socialUseCase.revokeAccount(providerId);
             throw new UnauthorizedException(AuthErrorType.CANNOT_GET_USER_DETAIL);
         }
     }

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -85,7 +85,8 @@ public class AuthFacade {
     public JwtTokenResponse loginByApple(AppleLoginRequest request) {
         final AccountProfileResponse profile =
                 socialUseCase.getAppleAccountToken(
-                        AppleMapper.toCommand(request), "https://patient-ocelot-accurate.ngrok-free.app");
+                        AppleMapper.toCommand(request),
+                        "https://patient-ocelot-accurate.ngrok-free.app");
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }

--- a/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/facade/AuthFacade.java
@@ -85,8 +85,7 @@ public class AuthFacade {
     public JwtTokenResponse loginByApple(AppleLoginRequest request) {
         final AccountProfileResponse profile =
                 socialUseCase.getAppleAccountToken(
-                        AppleMapper.toCommand(request),
-                        "https://patient-ocelot-accurate.ngrok-free.app");
+                        AppleMapper.toCommand(request), "https://swimie.life");
         if (profile == null) {
             throw new NotFoundException(AuthErrorType.NOT_FOUND);
         }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #413

## 📌 작업 내용 및 특이사항
1. 애플 로그인 요청이 들어온다
2. DB에 계정이 있는가? 있으면 로그인을 진행해준다. 종료
3. 없으면 이메일과 닉네임이 있는가? 있으면 DB에 계정 정보를 저장하고 로그인을 진행해준다. 종료
4. 없으면 연결 끊기를 진행하고 클라이언트로 특정 오류 응답을 보낸다.
5. 해당 오류 응답을 받은 클라이언트는 오류 페이지를 제공한다. (다시 로그인을 시도하세요)
6. 다시 1로 진행

## 📝 참고사항
- 성공 영상 (흰 화면이 보이는 이유는 `https://localhost:3000`으로 리다이렉트 되어서 그렇고, 실 서버에서는 문제없이 작동합니다.)
https://github.com/user-attachments/assets/8b7b59ed-1ccc-45e1-90a0-34706d5b39d4