### PR TITLE
refactor: 로그 추적을 용이하게 하기 위한 MDC 적용

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
+++ b/module-presentation/src/main/java/com/depromeet/auth/api/AuthController.java
@@ -6,7 +6,7 @@ import com.depromeet.auth.dto.request.KakaoLoginRequest;
 import com.depromeet.auth.dto.response.JwtAccessTokenResponse;
 import com.depromeet.auth.dto.response.JwtTokenResponse;
 import com.depromeet.auth.facade.AuthFacade;
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.type.auth.AuthSuccessType;

--- a/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistController.java
+++ b/module-presentation/src/main/java/com/depromeet/blacklist/api/BlacklistController.java
@@ -3,7 +3,7 @@ package com.depromeet.blacklist.api;
 import com.depromeet.blacklist.dto.request.BlackMemberRequest;
 import com.depromeet.blacklist.dto.response.BlackMemberResponse;
 import com.depromeet.blacklist.facade.BlacklistFacade;
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.type.blacklist.BlacklistSuccessType;

--- a/module-presentation/src/main/java/com/depromeet/config/correlationid/MDCFilter.java
+++ b/module-presentation/src/main/java/com/depromeet/config/correlationid/MDCFilter.java
@@ -1,0 +1,24 @@
+package com.depromeet.config.correlationid;
+
+import jakarta.servlet.*;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MDCFilter implements Filter {
+    @Override
+    public void doFilter(
+            ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        final UUID uuid = UUID.randomUUID();
+        String requestId = uuid.toString().replaceAll("-", "");
+        MDC.put("request_id", requestId);
+        filterChain.doFilter(servletRequest, servletResponse);
+        MDC.clear();
+    }
+}

--- a/module-presentation/src/main/java/com/depromeet/config/log/LoggerConfig.java
+++ b/module-presentation/src/main/java/com/depromeet/config/log/LoggerConfig.java
@@ -1,4 +1,4 @@
-package com.depromeet.config;
+package com.depromeet.config.log;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,7 +18,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Aspect
 @Configuration
 public class LoggerConfig {
-    @Around("@annotation(com.depromeet.config.Logging) && @annotation(logging)")
+    @Around("@annotation(com.depromeet.config.log.Logging) && @annotation(logging)")
     public Object aroundLogger(ProceedingJoinPoint joinPoint, Logging logging) throws Throwable {
         RequestLog requestLog = new RequestLog();
 

--- a/module-presentation/src/main/java/com/depromeet/config/log/Logging.java
+++ b/module-presentation/src/main/java/com/depromeet/config/log/Logging.java
@@ -1,4 +1,4 @@
-package com.depromeet.config;
+package com.depromeet.config.log;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/module-presentation/src/main/java/com/depromeet/config/log/RequestLog.java
+++ b/module-presentation/src/main/java/com/depromeet/config/log/RequestLog.java
@@ -1,4 +1,4 @@
-package com.depromeet.config;
+package com.depromeet.config.log;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/module-presentation/src/main/java/com/depromeet/config/log/mdc/MDCFilter.java
+++ b/module-presentation/src/main/java/com/depromeet/config/log/mdc/MDCFilter.java
@@ -1,4 +1,4 @@
-package com.depromeet.config.correlationid;
+package com.depromeet.config.log.mdc;
 
 import jakarta.servlet.*;
 import java.io.IOException;

--- a/module-presentation/src/main/java/com/depromeet/config/log/mdc/MDCFilter.java
+++ b/module-presentation/src/main/java/com/depromeet/config/log/mdc/MDCFilter.java
@@ -2,7 +2,6 @@ package com.depromeet.config.log.mdc;
 
 import jakarta.servlet.*;
 import java.io.IOException;
-import java.util.UUID;
 import org.slf4j.MDC;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -15,9 +14,9 @@ public class MDCFilter implements Filter {
     public void doFilter(
             ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
-        final UUID uuid = UUID.randomUUID();
-        String requestId = uuid.toString().replaceAll("-", "");
-        MDC.put("request_id", requestId);
+
+        String clientIp = servletRequest.getRemoteAddr();
+        MDC.put("request_id", clientIp);
         filterChain.doFilter(servletRequest, servletResponse);
         MDC.clear();
     }

--- a/module-presentation/src/main/java/com/depromeet/followinglog/api/FollowingLogController.java
+++ b/module-presentation/src/main/java/com/depromeet/followinglog/api/FollowingLogController.java
@@ -2,7 +2,7 @@ package com.depromeet.followinglog.api;
 
 import static com.depromeet.type.followingLog.FollowingLogSuccessType.GET_FOLLOWING_LOGS_SUCCESS;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.followinglog.dto.response.FollowingLogSliceResponse;
 import com.depromeet.followinglog.facade.FollowingLogFacade;

--- a/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
+++ b/module-presentation/src/main/java/com/depromeet/friend/api/FollowController.java
@@ -1,6 +1,6 @@
 package com.depromeet.friend.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.friend.dto.request.FollowRequest;
 import com.depromeet.friend.dto.response.*;

--- a/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
+++ b/module-presentation/src/main/java/com/depromeet/image/api/ImageController.java
@@ -2,7 +2,7 @@ package com.depromeet.image.api;
 
 import static com.depromeet.type.image.ImageSuccessType.*;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.image.dto.request.ImageIdsRequest;
 import com.depromeet.image.dto.request.ImageNameRequest;

--- a/module-presentation/src/main/java/com/depromeet/member/api/GoalController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/GoalController.java
@@ -1,6 +1,6 @@
 package com.depromeet.member.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.member.domain.Member;

--- a/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
+++ b/module-presentation/src/main/java/com/depromeet/member/api/MemberController.java
@@ -1,6 +1,6 @@
 package com.depromeet.member.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.member.domain.Member;

--- a/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/api/MemoryController.java
@@ -1,6 +1,6 @@
 package com.depromeet.memory.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.memory.dto.request.MemoryCreateRequest;

--- a/module-presentation/src/main/java/com/depromeet/notification/api/NotificationController.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/api/NotificationController.java
@@ -1,6 +1,6 @@
 package com.depromeet.notification.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.notification.dto.request.UpdateReadNotificationRequest;

--- a/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
+++ b/module-presentation/src/main/java/com/depromeet/pool/api/PoolController.java
@@ -1,6 +1,6 @@
 package com.depromeet.pool.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.pool.dto.request.FavoritePoolCreateRequest;

--- a/module-presentation/src/main/java/com/depromeet/reaction/api/ReactionController.java
+++ b/module-presentation/src/main/java/com/depromeet/reaction/api/ReactionController.java
@@ -1,6 +1,6 @@
 package com.depromeet.reaction.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.reaction.dto.request.ReactionCreateRequest;

--- a/module-presentation/src/main/java/com/depromeet/report/api/ReportController.java
+++ b/module-presentation/src/main/java/com/depromeet/report/api/ReportController.java
@@ -1,6 +1,6 @@
 package com.depromeet.report.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
 import com.depromeet.report.dto.request.ReportRequest;

--- a/module-presentation/src/main/java/com/depromeet/withdrawal/api/WithdrawalReasonController.java
+++ b/module-presentation/src/main/java/com/depromeet/withdrawal/api/WithdrawalReasonController.java
@@ -1,6 +1,6 @@
 package com.depromeet.withdrawal.api;
 
-import com.depromeet.config.Logging;
+import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.type.withdrawal.WithdrawalReasonSuccessType;
 import com.depromeet.withdrawal.dto.request.WithdrawalReasonCreateRequest;

--- a/module-presentation/src/main/resources/logback-spring.xml
+++ b/module-presentation/src/main/resources/logback-spring.xml
@@ -3,8 +3,8 @@
     <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
 
     <property name="CONSOLE_LOG_PATTERN"
-              value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %clr(%5level) %cyan(%logger) - %msg%n"/>
-    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level %logger - %msg%n"/>
+              value="%green(%d{yyyy-MM-dd HH:mm:ss.SSS}) %magenta([%thread]) %clr(%5level) [%X{request_id:-no_request_id}] %cyan(%logger) - %msg%n"/>
+    <property name="FILE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %5level [%X{request_id:-no_request_id}] %logger - %msg%n"/>
 
     <!--local-->
     <springProfile name="local">

--- a/scripts/Dockerfile-dev
+++ b/scripts/Dockerfile-dev
@@ -4,4 +4,4 @@ WORKDIR /app
 
 COPY module-presentation/build/libs/module-presentation.jar /app/appu.jar
 
-CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=dev", "appu.jar"]
+CMD ["java", "-Djava.net.preferIPv4Stack=true", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev", "-jar", "appu.jar"]

--- a/scripts/Dockerfile-image
+++ b/scripts/Dockerfile-image
@@ -4,4 +4,4 @@ WORKDIR /app
 
 COPY module-batch/build/libs/module-batch.jar /app/batch-image.jar
 
-CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=batch", "batch-image.jar"]
+CMD ["java", "-Djava.net.preferIPv4Stack=true", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=batch", "-jar", "batch-image.jar"]

--- a/scripts/Dockerfile-prod
+++ b/scripts/Dockerfile-prod
@@ -4,4 +4,4 @@ WORKDIR /app
 
 COPY module-presentation/build/libs/module-presentation.jar /app/appu.jar
 
-CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=prod", "appu.jar"]
+CMD ["java", "-Djava.net.preferIPv4Stack=true", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=prod", "-jar", "appu.jar"]


### PR DESCRIPTION
## 🌱 관련 이슈

- close #353 

## 📌 작업 내용 및 특이사항
- 로그 추적을 위해 MDC를 추가하였습니다. 
- MDCFilter를 통해 모든 요청에 대해 request_id 가 붙게 됩니다. (request_id는 클라이언트의 IP 로 임시로 지정해놓았습니다.)
- 추후 Nginx request_id를 활용하는 방법으로 업그레이드를 해보겠습니다

## 📝 참고사항
적용 결과 (도커 데스크톱 로그 출력)
![KakaoTalk_20240911_223805312](https://github.com/user-attachments/assets/1d9d3aa9-0b14-48b4-b975-b94daea0dc37)

