### PR TITLE
feat: MySQL Replication 수행

### DIFF
--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/DataSourceConfig.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/DataSourceConfig.java
@@ -1,0 +1,58 @@
+package com.depromeet.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@Configuration
+@Profile("prod")
+public class DataSourceConfig {
+    private static final String PRIMARY_SOURCE = "primaryDataSource";
+    private static final String SECONDARY_SOURCE = "secondaryDataSource";
+
+    @Bean(PRIMARY_SOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.primary.hikari")
+    public DataSource primaryDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean(SECONDARY_SOURCE)
+    @ConfigurationProperties(prefix = "spring.datasource.secondary.hikari")
+    public DataSource secondaryDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(
+            @Qualifier(PRIMARY_SOURCE) DataSource primaryDataSource,
+            @Qualifier(SECONDARY_SOURCE) DataSource secondaryDataSource) {
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("primary", primaryDataSource);
+        dataSourceMap.put("secondary", secondaryDataSource);
+
+        Map<Object, Object> immutableDataSourceMap = Collections.unmodifiableMap(dataSourceMap);
+
+        routingDataSource.setTargetDataSources(immutableDataSourceMap);
+        routingDataSource.setDefaultTargetDataSource(primaryDataSource);
+
+        return routingDataSource;
+    }
+
+    @Bean
+    @Primary
+    public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/JpaAuditingConfig.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/JpaAuditingConfig.java
@@ -1,0 +1,8 @@
+package com.depromeet.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/JpaConfig.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/JpaConfig.java
@@ -1,8 +1,64 @@
 package com.depromeet.config;
 
+import java.util.Properties;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.context.annotation.Profile;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
-@EnableJpaAuditing
-public class JpaConfig {}
+@EnableTransactionManagement
+@Profile("prod")
+public class JpaConfig {
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            @Qualifier("dataSource") DataSource dataSource) {
+        LocalContainerEntityManagerFactoryBean entityManagerFactory =
+                new LocalContainerEntityManagerFactoryBean();
+        entityManagerFactory.setDataSource(dataSource);
+        entityManagerFactory.setPackagesToScan("com.depromeet");
+        entityManagerFactory.setJpaVendorAdapter(jpaVendorAdapter());
+        entityManagerFactory.setPersistenceUnitName("entityManager");
+        entityManagerFactory.setJpaProperties(hibernateProperties());
+
+        return entityManagerFactory;
+    }
+
+    private JpaVendorAdapter jpaVendorAdapter() {
+        HibernateJpaVendorAdapter hibernateJpaVendorAdapter = new HibernateJpaVendorAdapter();
+
+        hibernateJpaVendorAdapter.setShowSql(true);
+        hibernateJpaVendorAdapter.setDatabase(Database.MYSQL);
+        hibernateJpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQLDialect");
+        return hibernateJpaVendorAdapter;
+    }
+
+    private Properties hibernateProperties() {
+        Properties properties = new Properties();
+
+        properties.setProperty("hibernate.hbm2ddl.auto", "none");
+        properties.setProperty("hibernate.format_sql", "true");
+        properties.setProperty(
+                "hibernate.physical_naming_strategy",
+                "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");
+
+        return properties;
+    }
+
+    @Bean
+    public PlatformTransactionManager transactionManager(
+            @Qualifier("entityManagerFactory")
+                    LocalContainerEntityManagerFactoryBean entityManagerFactory) {
+        JpaTransactionManager jpaTransactionManager = new JpaTransactionManager();
+        jpaTransactionManager.setEntityManagerFactory(entityManagerFactory.getObject());
+        return jpaTransactionManager;
+    }
+}

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/JpaConfig.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/JpaConfig.java
@@ -35,7 +35,7 @@ public class JpaConfig {
     private JpaVendorAdapter jpaVendorAdapter() {
         HibernateJpaVendorAdapter hibernateJpaVendorAdapter = new HibernateJpaVendorAdapter();
 
-        hibernateJpaVendorAdapter.setShowSql(true);
+        hibernateJpaVendorAdapter.setShowSql(false);
         hibernateJpaVendorAdapter.setDatabase(Database.MYSQL);
         hibernateJpaVendorAdapter.setDatabasePlatform("org.hibernate.dialect.MySQLDialect");
         return hibernateJpaVendorAdapter;
@@ -45,7 +45,7 @@ public class JpaConfig {
         Properties properties = new Properties();
 
         properties.setProperty("hibernate.hbm2ddl.auto", "none");
-        properties.setProperty("hibernate.format_sql", "true");
+        properties.setProperty("hibernate.format_sql", "false");
         properties.setProperty(
                 "hibernate.physical_naming_strategy",
                 "org.hibernate.boot.model.naming.CamelCaseToUnderscoresNamingStrategy");

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/RoutingDataSource.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/config/RoutingDataSource.java
@@ -1,0 +1,12 @@
+package com.depromeet.config;
+
+import static org.springframework.transaction.support.TransactionSynchronizationManager.*;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return isCurrentTransactionReadOnly() ? "secondary" : "primary";
+    }
+}

--- a/module-presentation/src/main/resources/application-prod-db.yml
+++ b/module-presentation/src/main/resources/application-prod-db.yml
@@ -1,0 +1,27 @@
+spring:
+  config:
+    activate:
+      on-profile: prod-db
+  datasource:
+    primary:
+      hikari:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        jdbc-url: ${PRIMARY_MYSQL_URL} # 환경변수에 값 추가하시면 됩니다.
+        username: ${PRIMARY_MYSQL_USERNAME}
+        password: ${PRIMARY_MYSQL_PASSWORD}
+
+    secondary:
+      hikari:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        jdbc-url: ${SECONDARY_MYSQL_URL} # 환경변수에 값 추가하시면 됩니다.
+        username: ${SECONDARY_MYSQL_USERNAME}
+        password: ${SECONDARY_MYSQL_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PW}
+
+logging:
+  level:
+    org.springframework.orm.jpa: INFO

--- a/module-presentation/src/main/resources/application-prod-db.yml
+++ b/module-presentation/src/main/resources/application-prod-db.yml
@@ -6,14 +6,14 @@ spring:
     primary:
       hikari:
         driver-class-name: com.mysql.cj.jdbc.Driver
-        jdbc-url: ${PRIMARY_MYSQL_URL} # 환경변수에 값 추가하시면 됩니다.
+        jdbc-url: ${PRIMARY_MYSQL_URL}
         username: ${PRIMARY_MYSQL_USERNAME}
         password: ${PRIMARY_MYSQL_PASSWORD}
 
     secondary:
       hikari:
         driver-class-name: com.mysql.cj.jdbc.Driver
-        jdbc-url: ${SECONDARY_MYSQL_URL} # 환경변수에 값 추가하시면 됩니다.
+        jdbc-url: ${SECONDARY_MYSQL_URL}
         username: ${SECONDARY_MYSQL_USERNAME}
         password: ${SECONDARY_MYSQL_PASSWORD}
   data:

--- a/module-presentation/src/main/resources/application.yml
+++ b/module-presentation/src/main/resources/application.yml
@@ -3,4 +3,4 @@ spring:
     active: local # default
     group:
       local: db, security, actuator, spreadsheet
-      prod: db, security, actuator, spreadsheet
+      prod: prod-db, security, actuator, spreadsheet


### PR DESCRIPTION
## 🌱 관련 이슈

- close #405 

## 📌 작업 내용 및 특이사항
- `MySQL 이중화`를 위한 어플리케이션 설정 변경을 수행하였습니다.
- Master, Slave 대신 `Primary, Secondary`라는 명칭을 사용하였습니다.
- `Primary` 노드는 `INSERT, UPDATE, DELETE`를 수행합니다.
- `Secondary` 노드는 오로지 쿼리 `GET`만을 수행합니다.

- Primary에 새로운 레코드나 수정 사항이 생기면 `Primary 노드`의 `바이너리 로그`에 쓰여집니다.
- 바이너리 로그에 쓰여지면 Primary 노드의 덤프 쓰레드가 변경 사항을 `Secondary 노드의 I/O 쓰레드`에 이를 전달합니다.
- Secondary I/O 노드는 변경 사항을 받아 이를 `릴레이 로그`에 씁니다.
- 릴레이 로그에 쓰여진 이후 `Secondary 노드`에 `SQL 쓰레드`가 변경 사항에 대해 이를 `기록`합니다.


## 📝 참고사항
![image](https://github.com/user-attachments/assets/90e3a0ac-b8f7-4f19-b0f3-e0792e5105a6)
