### PR TITLE
refactor: 알림 일괄 읽음 처리

### DIFF
--- a/module-domain/src/main/java/com/depromeet/notification/port/in/usecase/UpdateFollowLogUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/in/usecase/UpdateFollowLogUseCase.java
@@ -1,7 +1,5 @@
 package com.depromeet.notification.port.in.usecase;
 
-import com.depromeet.notification.port.in.command.UpdateReadFollowLogCommand;
-
 public interface UpdateFollowLogUseCase {
-    void markAsReadFollowLog(Long memberId, UpdateReadFollowLogCommand command);
+    void markAsReadFollowLogs(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/notification/port/in/usecase/UpdateReactionLogUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/in/usecase/UpdateReactionLogUseCase.java
@@ -1,5 +1,5 @@
 package com.depromeet.notification.port.in.usecase;
 
 public interface UpdateReactionLogUseCase {
-    void markAsReadReactionLog(Long memberId, Long reactionLogId);
+    void markAsReadReactionLogs(Long memberId);
 }

--- a/module-domain/src/main/java/com/depromeet/notification/port/out/FollowLogPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/out/FollowLogPersistencePort.java
@@ -1,7 +1,6 @@
 package com.depromeet.notification.port.out;
 
 import com.depromeet.notification.domain.FollowLog;
-import com.depromeet.notification.domain.FollowType;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -10,7 +9,7 @@ public interface FollowLogPersistencePort {
 
     List<FollowLog> findByMemberIdAndCursorCreatedAt(Long memberId, LocalDateTime cursorCreatedAt);
 
-    void updateRead(Long memberId, Long followLogId, FollowType type);
+    void updateAllAsRead(Long memberId);
 
     Long countUnread(Long memberId);
 

--- a/module-domain/src/main/java/com/depromeet/notification/port/out/ReactionLogPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/notification/port/out/ReactionLogPersistencePort.java
@@ -10,7 +10,7 @@ public interface ReactionLogPersistencePort {
     List<ReactionLog> findByMemberIdAndCursorCreatedAt(
             Long memberId, LocalDateTime cursorCreatedAt);
 
-    void updateRead(Long memberId, Long reactionLogId);
+    void updateAllAsRead(Long memberId);
 
     Long countUnread(Long memberId);
 

--- a/module-domain/src/main/java/com/depromeet/notification/service/FollowLogService.java
+++ b/module-domain/src/main/java/com/depromeet/notification/service/FollowLogService.java
@@ -4,7 +4,6 @@ import com.depromeet.friend.port.out.persistence.FriendPersistencePort;
 import com.depromeet.notification.domain.FollowLog;
 import com.depromeet.notification.domain.FollowType;
 import com.depromeet.notification.event.FollowLogEvent;
-import com.depromeet.notification.port.in.command.UpdateReadFollowLogCommand;
 import com.depromeet.notification.port.in.usecase.DeleteFollowLogUseCase;
 import com.depromeet.notification.port.in.usecase.GetFollowLogUseCase;
 import com.depromeet.notification.port.in.usecase.UpdateFollowLogUseCase;
@@ -72,8 +71,8 @@ public class FollowLogService
     }
 
     @Override
-    public void markAsReadFollowLog(Long memberId, UpdateReadFollowLogCommand command) {
-        followLogPersistencePort.updateRead(memberId, command.followLogId(), command.type());
+    public void markAsReadFollowLogs(Long memberId) {
+        followLogPersistencePort.updateAllAsRead(memberId);
     }
 
     @Override

--- a/module-domain/src/main/java/com/depromeet/notification/service/ReactionLogService.java
+++ b/module-domain/src/main/java/com/depromeet/notification/service/ReactionLogService.java
@@ -47,8 +47,8 @@ public class ReactionLogService
 
     @Override
     @Transactional
-    public void markAsReadReactionLog(Long memberId, Long reactionLogId) {
-        reactionLogPersistencePort.updateRead(memberId, reactionLogId);
+    public void markAsReadReactionLogs(Long memberId) {
+        reactionLogPersistencePort.updateAllAsRead(memberId);
     }
 
     @Override

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/FollowLogRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/FollowLogRepository.java
@@ -50,10 +50,10 @@ public class FollowLogRepository implements FollowLogPersistencePort {
     }
 
     @Override
-    public void updateRead(Long memberId, Long followLogId, FollowType type) {
+    public void updateAllAsRead(Long memberId) {
         queryFactory
                 .update(followLogEntity)
-                .where(memberEq(memberId), followLogEq(followLogId), followTypeEq(type))
+                .where(memberEq(memberId), followLogEntity.hasRead.eq(false))
                 .set(followLogEntity.hasRead, true)
                 .execute();
     }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/ReactionLogRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/notification/repository/ReactionLogRepository.java
@@ -54,9 +54,12 @@ public class ReactionLogRepository implements ReactionLogPersistencePort {
     }
 
     @Override
-    public void updateRead(Long memberId, Long reactionLogId) {
-        ReactionLogEntity reactionLogEntity = findByMemberIdAndLogId(memberId, reactionLogId);
-        reactionLogEntity.updateHasRead(true);
+    public void updateAllAsRead(Long memberId) {
+        queryFactory
+                .update(reactionLogEntity)
+                .where(memberEq(memberId), reactionLogEntity.hasRead.isFalse())
+                .set(reactionLogEntity.hasRead, true)
+                .execute();
     }
 
     @Override

--- a/module-presentation/src/main/java/com/depromeet/notification/api/NotificationApi.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/api/NotificationApi.java
@@ -2,7 +2,6 @@ package com.depromeet.notification.api;
 
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
-import com.depromeet.notification.dto.request.UpdateReadNotificationRequest;
 import com.depromeet.notification.dto.response.NotificationResponse;
 import com.depromeet.notification.dto.response.UnreadNotificationCountResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,7 +9,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDateTime;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "알림(Notification)")
@@ -28,6 +26,5 @@ public interface NotificationApi {
             @LoginMember Long memberId);
 
     @Operation(summary = "알림 읽음 처리")
-    ApiResponse<?> markAsReadNotification(
-            @LoginMember Long memberId, @RequestBody UpdateReadNotificationRequest request);
+    ApiResponse<?> markAllAsReadNotification(@LoginMember Long memberId);
 }

--- a/module-presentation/src/main/java/com/depromeet/notification/api/NotificationController.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/api/NotificationController.java
@@ -3,7 +3,6 @@ package com.depromeet.notification.api;
 import com.depromeet.config.log.Logging;
 import com.depromeet.dto.response.ApiResponse;
 import com.depromeet.member.annotation.LoginMember;
-import com.depromeet.notification.dto.request.UpdateReadNotificationRequest;
 import com.depromeet.notification.dto.response.NotificationResponse;
 import com.depromeet.notification.dto.response.UnreadNotificationCountResponse;
 import com.depromeet.notification.facade.NotificationFacade;
@@ -13,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,10 +44,9 @@ public class NotificationController implements NotificationApi {
     }
 
     @PatchMapping("/read")
-    @Logging(item = "Notification", action = "POST")
-    public ApiResponse<?> markAsReadNotification(
-            @LoginMember Long memberId, @RequestBody UpdateReadNotificationRequest request) {
-        notificationFacade.markAsReadNotification(memberId, request);
+    @Logging(item = "Notification", action = "PATCH")
+    public ApiResponse<?> markAllAsReadNotification(@LoginMember Long memberId) {
+        notificationFacade.markAsReadNotification(memberId);
         return ApiResponse.success(NotificationSuccessType.MARK_AS_READ_NOTIFICATION_SUCCESS);
     }
 }

--- a/module-presentation/src/main/java/com/depromeet/notification/facade/NotificationFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/facade/NotificationFacade.java
@@ -1,24 +1,20 @@
 package com.depromeet.notification.facade;
 
-import com.depromeet.exception.BadRequestException;
 import com.depromeet.exception.InternalServerException;
 import com.depromeet.notification.domain.FollowLog;
 import com.depromeet.notification.domain.FollowType;
 import com.depromeet.notification.domain.ReactionLog;
-import com.depromeet.notification.dto.request.UpdateReadNotificationRequest;
 import com.depromeet.notification.dto.response.BaseNotificationResponse;
 import com.depromeet.notification.dto.response.FollowNotificationResponse;
 import com.depromeet.notification.dto.response.FriendNotificationResponse;
 import com.depromeet.notification.dto.response.NotificationResponse;
 import com.depromeet.notification.dto.response.ReactionNotificationResponse;
 import com.depromeet.notification.dto.response.UnreadNotificationCountResponse;
-import com.depromeet.notification.mapper.NotificationMapper;
 import com.depromeet.notification.port.in.usecase.GetFollowLogUseCase;
 import com.depromeet.notification.port.in.usecase.GetReactionLogUseCase;
 import com.depromeet.notification.port.in.usecase.UpdateFollowLogUseCase;
 import com.depromeet.notification.port.in.usecase.UpdateReactionLogUseCase;
 import com.depromeet.type.friend.FollowErrorType;
-import com.depromeet.type.notification.NotificationErrorType;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +36,7 @@ public class NotificationFacade {
     @Value("${cloud-front.domain}")
     private String profileImageOrigin;
 
+    @Transactional
     public NotificationResponse getNotifications(Long memberId, LocalDateTime cursorCreatedAt) {
         List<FollowLog> followLogs = getFollowLogUseCase.getFollowLogs(memberId, cursorCreatedAt);
         List<Long> friendList = new ArrayList<>();
@@ -96,15 +93,17 @@ public class NotificationFacade {
     }
 
     @Transactional
-    public void markAsReadNotification(Long memberId, UpdateReadNotificationRequest request) {
-        if (request.type().equals("CHEER")) {
-            updateReactionLogUseCase.markAsReadReactionLog(memberId, request.notificationId());
-        } else if (request.type().equals("FOLLOW") || request.type().equals("FRIEND")) {
-            updateFollowLogUseCase.markAsReadFollowLog(
-                    memberId, NotificationMapper.toCommand(request));
-        } else {
-            throw new BadRequestException(NotificationErrorType.INVALID_NOTIFICATION_TYPE);
-        }
+    public void markAsReadNotification(Long memberId) {
+        updateFollowLogUseCase.markAsReadFollowLogs(memberId);
+        updateReactionLogUseCase.markAsReadReactionLogs(memberId);
+        // if (request.type().equals("CHEER")) {
+        //     updateReactionLogUseCase.markAsReadReactionLog(memberId, request.notificationId());
+        // } else if (request.type().equals("FOLLOW") || request.type().equals("FRIEND")) {
+        //     updateFollowLogUseCase.markAsReadFollowLog(
+        //             memberId, NotificationMapper.toCommand(request));
+        // } else {
+        //     throw new BadRequestException(NotificationErrorType.INVALID_NOTIFICATION_TYPE);
+        // }
     }
 
     public UnreadNotificationCountResponse getUnreadNotificationCount(Long memberId) {

--- a/module-presentation/src/main/java/com/depromeet/notification/facade/NotificationFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/notification/facade/NotificationFacade.java
@@ -96,14 +96,6 @@ public class NotificationFacade {
     public void markAsReadNotification(Long memberId) {
         updateFollowLogUseCase.markAsReadFollowLogs(memberId);
         updateReactionLogUseCase.markAsReadReactionLogs(memberId);
-        // if (request.type().equals("CHEER")) {
-        //     updateReactionLogUseCase.markAsReadReactionLog(memberId, request.notificationId());
-        // } else if (request.type().equals("FOLLOW") || request.type().equals("FRIEND")) {
-        //     updateFollowLogUseCase.markAsReadFollowLog(
-        //             memberId, NotificationMapper.toCommand(request));
-        // } else {
-        //     throw new BadRequestException(NotificationErrorType.INVALID_NOTIFICATION_TYPE);
-        // }
     }
 
     public UnreadNotificationCountResponse getUnreadNotificationCount(Long memberId) {

--- a/module-presentation/src/main/resources/application-prod.yml
+++ b/module-presentation/src/main/resources/application-prod.yml
@@ -9,9 +9,9 @@ spring:
     defer-datasource-initialization: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         default_batch_fetch_size: 100
-    show-sql: true
+    show-sql: false
   sql:
     init:
       mode: never

--- a/scripts/Dockerfile-prod
+++ b/scripts/Dockerfile-prod
@@ -1,7 +1,20 @@
-FROM amazoncorretto:21
+# Build stage: 소스 코드를 빌드하는 단계
+FROM amazoncorretto:21-alpine-jdk AS build
+
+WORKDIR /home/gradle/src
+
+# 소스 코드를 컨테이너로 복사
+COPY . .
+
+# Gradle을 이용하여 module-presentation 모듈만 빌드
+RUN ./gradlew :module-presentation:build
+
+# Run stage: 최종 경량 이미지를 생성하는 단계
+FROM optimoz/openjre-21.0.3:0.4
 
 WORKDIR /app
 
-COPY module-presentation/build/libs/module-presentation.jar /app/appu.jar
+COPY --from=build /home/gradle/src/module-presentation/build/libs/module-presentation.jar /app/appu.jar
 
 CMD ["java", "-Djava.net.preferIPv4Stack=true", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=prod", "-jar", "appu.jar"]
+

--- a/scripts/Dockerfile-prod
+++ b/scripts/Dockerfile-prod
@@ -17,4 +17,3 @@ WORKDIR /app
 COPY --from=build /home/gradle/src/module-presentation/build/libs/module-presentation.jar /app/appu.jar
 
 CMD ["java", "-Djava.net.preferIPv4Stack=true", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=prod", "-jar", "appu.jar"]
-

--- a/scripts/Jenkinsfile
+++ b/scripts/Jenkinsfile
@@ -28,14 +28,12 @@ pipeline {
             steps {
                 sh 'chmod u+w ./module-presentation/src/main/resources/'
                 sh 'chmod +x ./gradlew'
-                sh './gradlew :module-presentation:build'
             }
         }
 
         stage('Docker 이미지 빌드') {
             steps {
                 script {
-                    sh 'cp ./module-presentation/build/libs/module-presentation.jar .'
                     dockerImage = docker.build(repository + ":latest", "-f ./scripts/Dockerfile-prod .")
                 }
             }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #422 

## 📌 작업 내용 및 특이사항
- 알림을 클릭 시 `hasRead=true`로 처리하는 것이 아니라 알림 창에 들어갔을 때 미확인 알림을 모두 `hasRead=true`로 처리하도록 변경하였습니다.
- Dockerfile 내부에 gradle build를 포함하였습니다. 추후 CI/CD 파이프라인 설계 변경 시 빌드 스크립트 수정이 필요하지 않도록 하고, 멀티 스테이징 이미지 빌드를 통해 `이미지 크기 최적화`를 수행하였습니다. (`620`MB -> `366`MB)
- Production 서버의 SQL문 출력을 제거하였습니다. (application-prod.yml 참고)

## 📝 참고사항
<img width="595" alt="image" src="https://github.com/user-attachments/assets/cf402fcb-fd70-4c52-b9a4-741ab41d5f58">
