### PR TITLE
hotfix: 타임라인 조회 시 응원 개수가 제대로 카운트 되지 않는 이슈 해결

### DIFF
--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/reaction/repository/ReactionRepository.java
@@ -139,6 +139,7 @@ public class ReactionRepository implements ReactionPersistencePort {
                 .from(reactionEntity)
                 .join(reactionEntity.memory, memoryEntity)
                 .where(memoryEntity.id.in(memoryIds))
+                .groupBy(memoryEntity.id)
                 .fetch();
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #424

## 📌 작업 내용 및 특이사항
- 타임라인 조회 시 응원 개수가 제대로 집계되지 않는 문제가 있었습니다. 
- reaction 개수 세는 쿼리에 group by memory_id를 추가하여 해결하였습니다. 

## 📝 참고사항
![응원 개수 집계 수정 결과](https://github.com/user-attachments/assets/2ff3751d-40aa-41ae-ade3-da78a107f063)
