### PR TITLE
refactor: 수영 기록 상세 조회 시 순서 방식 변경

### DIFF
--- a/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/in/usecase/GetMemoryUseCase.java
@@ -11,7 +11,7 @@ public interface GetMemoryUseCase {
 
     Memory findByIdWithMember(Long memoryId);
 
-    int findOrderInMonth(Long memberId, Long memoryId, int month);
+    int findCreationOrderInMonth(Long memberId, Long memoryId, int month);
 
     List<Memory> findByMemberId(Long memberId);
 
@@ -20,4 +20,6 @@ public interface GetMemoryUseCase {
     MemoryAndDetailId findMemoryAndDetailIdsByMemberId(Long memberId);
 
     MemoryIdAndDiaryAndMember findIdAndNicknameById(Long memberId);
+
+    int findDateOrderInMonth(Long memberId, Long memoryId, int month);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
+++ b/module-domain/src/main/java/com/depromeet/memory/port/out/persistence/MemoryPersistencePort.java
@@ -18,7 +18,7 @@ public interface MemoryPersistencePort {
 
     Optional<Memory> update(Long memoryId, Memory updateMemory);
 
-    int findOrderInMonth(Long memberId, Long memoryId, int month);
+    int findCreationOrderInMonth(Long memberId, Long memoryId, int month);
 
     List<Memory> findPrevMemoryByMemberId(Long memberId, LocalDate cursorRecordAt);
 
@@ -39,4 +39,6 @@ public interface MemoryPersistencePort {
     void deleteById(Long memoryId);
 
     Optional<MemoryIdAndDiaryAndMember> findIdAndNicknameById(Long memberId);
+
+    int findDateOrderInMonth(Long memberId, Long memoryId, int month);
 }

--- a/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
+++ b/module-domain/src/main/java/com/depromeet/memory/service/MemoryService.java
@@ -84,8 +84,13 @@ public class MemoryService
     }
 
     @Override
-    public int findOrderInMonth(Long memberId, Long memoryId, int month) {
-        return memoryPersistencePort.findOrderInMonth(memberId, memoryId, month);
+    public int findCreationOrderInMonth(Long memberId, Long memoryId, int month) {
+        return memoryPersistencePort.findCreationOrderInMonth(memberId, memoryId, month);
+    }
+
+    @Override
+    public int findDateOrderInMonth(Long memberId, Long memoryId, int month) {
+        return memoryPersistencePort.findDateOrderInMonth(memberId, memoryId, month);
     }
 
     @Override

--- a/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
+++ b/module-domain/src/test/java/com/depromeet/mock/memory/FakeMemoryRepository.java
@@ -106,7 +106,7 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public int findOrderInMonth(Long memberId, Long memoryId, int month) {
+    public int findCreationOrderInMonth(Long memberId, Long memoryId, int month) {
         return 0;
     }
 
@@ -208,5 +208,10 @@ public class FakeMemoryRepository implements MemoryPersistencePort {
                                         new MemberIdAndNickname(
                                                 item.getMember().getId(),
                                                 item.getMember().getNickname())));
+    }
+
+    @Override
+    public int findDateOrderInMonth(Long memberId, Long memoryId, int month) {
+        return 0;
     }
 }

--- a/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
+++ b/module-infrastructure/persistence-database/src/main/java/com/depromeet/memory/repository/MemoryRepository.java
@@ -100,7 +100,7 @@ public class MemoryRepository implements MemoryPersistencePort {
     }
 
     @Override
-    public int findOrderInMonth(Long memberId, Long memoryId, int month) {
+    public int findCreationOrderInMonth(Long memberId, Long memoryId, int month) {
         return queryFactory
                         .select(memory.id)
                         .from(memory)
@@ -239,6 +239,18 @@ public class MemoryRepository implements MemoryPersistencePort {
         return Optional.of(
                 new MemoryIdAndDiaryAndMember(
                         result.get(0, Long.class), result.get(1, String.class), member));
+    }
+
+    @Override
+    public int findDateOrderInMonth(Long memberId, Long memoryId, int month) {
+        return queryFactory
+                        .select(memory.id)
+                        .from(memory)
+                        .where(memberEq(memberId), memory.recordAt.month().eq(month))
+                        .orderBy(memory.recordAt.asc())
+                        .fetch()
+                        .indexOf(memoryId)
+                + 1;
     }
 
     private BooleanExpression loeRecordAt(LocalDate recordAt) {

--- a/module-presentation/src/main/java/com/depromeet/config/log/mdc/MDCFilter.java
+++ b/module-presentation/src/main/java/com/depromeet/config/log/mdc/MDCFilter.java
@@ -15,8 +15,6 @@ public class MDCFilter implements Filter {
     public void doFilter(
             ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
-
-        String clientIp = servletRequest.getRemoteAddr();
         MDC.put("request_id", getClientIp(servletRequest));
         filterChain.doFilter(servletRequest, servletResponse);
         MDC.clear();

--- a/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/facade/MemoryFacade.java
@@ -70,7 +70,7 @@ public class MemoryFacade {
         Memory newMemory = createMemoryUseCase.save(writer, MemoryMapper.toCommand(request));
         Long memoryId = newMemory.getId();
         int month = request.getRecordAt().getMonth().getValue();
-        int rank = getMemoryUseCase.findOrderInMonth(memberId, memoryId, month);
+        int rank = getMemoryUseCase.findCreationOrderInMonth(memberId, memoryId, month);
 
         List<CreateStrokeCommand> commands =
                 request.getStrokes().stream().map(MemoryMapper::toCommand).toList();
@@ -108,8 +108,10 @@ public class MemoryFacade {
     public MemoryResponse findById(Long requestMemberId, Long memoryId) {
         MemoryInfo memoryInfo = getMemoryUseCase.findByIdWithPrevNext(requestMemberId, memoryId);
         Long memoryMemberId = memoryInfo.memory().getMember().getId();
+
         int month = memoryInfo.memory().getRecordAt().getMonth().getValue();
-        int rank = getMemoryUseCase.findOrderInMonth(memoryMemberId, memoryId, month);
+        int rank = getMemoryUseCase.findDateOrderInMonth(memoryMemberId, memoryId, month);
+
         return MemoryResponse.from(memoryInfo, rank);
     }
 


### PR DESCRIPTION
## 🌱 관련 이슈

- close #431 

## 📌 작업 내용 및 특이사항
- 수영 기록 상세 조회 시 순서의 방식이 변경되었습니다. 기록 생성 시에는 생성의 순서(id - auto increment)에 맞게 rank를 부여하고, 기록 상세 조회 시에는 기록 날짜의 순서(recordAt)를 기준으로 rank를 산정합니다.
- MDCFilter의 불필요한 코드를 제거했습니다.

## 📝 참고사항
기존에 1일과 5일에 데이터가 생성되어 있습니다. 새로 생성하는 기록의 날짜는 3일입니다.

`[생성 시에는 3번째]`
<img width="325" alt="스크린샷 2024-09-13 오후 3 53 13" src="https://github.com/user-attachments/assets/fc6a9a98-8651-4099-9beb-287e7d937fcb">

`[조회 시에는 2번째]`
<img width="313" alt="스크린샷 2024-09-13 오후 3 53 04" src="https://github.com/user-attachments/assets/437b1737-b78e-4652-a4e4-e4254207ea23">
