### PR TITLE
fix: 100일이 지난 팔로잉 소식 삭제 배치의 ItemReader 가 제대로 동작하지 않는 문제 해결

### DIFF
--- a/module-batch/src/main/java/com/depromeet/job/followinglog/reader/FollowingLogItemReader.java
+++ b/module-batch/src/main/java/com/depromeet/job/followinglog/reader/FollowingLogItemReader.java
@@ -34,6 +34,7 @@ public class FollowingLogItemReader implements ItemReader<FollowingMemoryLogEnti
     private void fetchNextPage() {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime before100Days = now.minusDays(100);
+        currentIndex = 0;
 
         TypedQuery<FollowingMemoryLogEntity> query =
                 em.createQuery(
@@ -43,6 +44,5 @@ public class FollowingLogItemReader implements ItemReader<FollowingMemoryLogEnti
         query.setFirstResult(currentIndex);
         query.setMaxResults(PAGE_SIZE);
         followingMemoryLogEntities = query.getResultList();
-        currentIndex = 0;
     }
 }

--- a/module-batch/src/main/java/com/depromeet/job/followinglog/reader/FollowingLogItemReader.java
+++ b/module-batch/src/main/java/com/depromeet/job/followinglog/reader/FollowingLogItemReader.java
@@ -21,7 +21,7 @@ public class FollowingLogItemReader implements ItemReader<FollowingMemoryLogEnti
     @Override
     public FollowingMemoryLogEntity read() {
         if (followingMemoryLogEntities == null
-                || currentIndex > followingMemoryLogEntities.size()) {
+                || currentIndex >= followingMemoryLogEntities.size()) {
             fetchNextPage();
         }
         if (followingMemoryLogEntities != null

--- a/module-domain/src/main/java/com/depromeet/report/service/ReportService.java
+++ b/module-domain/src/main/java/com/depromeet/report/service/ReportService.java
@@ -4,9 +4,11 @@ import com.depromeet.report.port.in.command.CreateReportCommand;
 import com.depromeet.report.port.in.usecase.CreateReportUseCase;
 import com.depromeet.report.port.out.persistence.ReportPersistencePort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
 @Service
+@Profile("!batch")
 @RequiredArgsConstructor
 public class ReportService implements CreateReportUseCase {
     private final ReportPersistencePort reportPersistencePort;

--- a/module-domain/src/main/java/com/depromeet/withdrawal/service/WithdrawalReasonService.java
+++ b/module-domain/src/main/java/com/depromeet/withdrawal/service/WithdrawalReasonService.java
@@ -5,11 +5,13 @@ import com.depromeet.withdrawal.port.in.command.CreateWithdrawalReasonCommand;
 import com.depromeet.withdrawal.port.in.usecase.CreateWithdrawalReasonUseCase;
 import com.depromeet.withdrawal.port.out.persistence.WithdrawalReasonPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
+@Profile("!batch")
 @RequiredArgsConstructor
 public class WithdrawalReasonService implements CreateWithdrawalReasonUseCase {
     private final WithdrawalReasonPort withdrawalReasonPort;


### PR DESCRIPTION
## 🌱 관련 이슈

- close #439 

## 📌 작업 내용 및 특이사항
- 100일이 지난 팔로잉 소식 삭제 배치의 ItemReader 가 제대로 동작하지 않는 문제가 있었습니다.
  - 100일이 지난 데이터를 최초 10개의 데이터만 삭제가 진행되고 이후 진행이 되지 않았었습니다.
  - 원인은 처음 10개의 데이터를 읽어온 이후, currentIndex와 followingMemoryLogEntities.size() 를 비교할 때 `>=` 가 아닌 `>` 로 비교가 되어 처음 10개 데이터를 읽어온 이후 바로 return null 을 해버렸기 때문이었습니다. 
```
if (followingMemoryLogEntities == null
                || currentIndex > followingMemoryLogEntities.size()) {
            fetchNextPage();
        }
```
- `>` 를 `>=`로 바꾸어 문제를 해결하였습니다.

## 📝 참고사항
- 배치 실행 시 앞부분의 일부 데이터가 지워지지 않는 문제 또한 발견하였습니다. 
- 원인은 최초 10개 데이터 삭제 후 두 번째 delete 작업 실행 시 currentIndex 가 0이 아닌 10으로 설정되어 발생한 문제였습니다. 
- fetchNextPage() 메서드 끝날 때 currentIndex를 0으로 초기화 하는 것이 아닌 메서드 처음 실행 시 currentIndex 를 0으로 초기화 하도록 로직을 변경했습니다. 