### PR TITLE
hotfix: 수영 시간 계산 시 초 단위로 계산

### DIFF
--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryReadUpdateResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryReadUpdateResponse.java
@@ -10,6 +10,7 @@ import com.depromeet.pool.domain.Pool;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -170,10 +171,8 @@ public class MemoryReadUpdateResponse {
     }
 
     private static LocalTime getDuration(LocalTime startTime, LocalTime endTime) {
-        return LocalTime.of(
-                endTime.minusHours(startTime.getHour()).getHour(),
-                endTime.minusMinutes(startTime.getMinute()).getMinute(),
-                0);
+        Duration duration = Duration.between(startTime, endTime);
+        return LocalTime.of(0, 0).plusSeconds(duration.getSeconds());
     }
 
     private static List<ImageSimpleResponse> getImageSource(List<Image> images) {

--- a/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
+++ b/module-presentation/src/main/java/com/depromeet/memory/dto/response/MemoryResponse.java
@@ -11,6 +11,7 @@ import com.depromeet.pool.domain.Pool;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -188,10 +189,8 @@ public class MemoryResponse {
     }
 
     private static LocalTime getDuration(LocalTime startTime, LocalTime endTime) {
-        return LocalTime.of(
-                endTime.minusHours(startTime.getHour()).getHour(),
-                endTime.minusMinutes(startTime.getMinute()).getMinute(),
-                0);
+        Duration duration = Duration.between(startTime, endTime);
+        return LocalTime.of(0, 0).plusSeconds(duration.getSeconds());
     }
 
     private static List<ImageSimpleResponse> getImageSource(List<Image> images) {


### PR DESCRIPTION
## 🌱 관련 이슈

- close #441

## 📌 작업 내용 및 특이사항
- 수영 시간을 계산할 때 시간끼리, 분끼리 차를 반환하고 있었습니다.
- 그러다보니 1시 30분 - 2시 20분은 1시(2-1) 50분(140 - 90) 으로 결과가 나오고 있었습니다.

**Solution**
- 먼저 Duration을 통해 시간 사이 간격을 구하고 0시 0분에서 초를 더하는 방식으로 해결하였습니다.